### PR TITLE
add user name field on sign up

### DIFF
--- a/app/controllers/hyku/registrations_controller.rb
+++ b/app/controllers/hyku/registrations_controller.rb
@@ -1,5 +1,6 @@
 module Hyku
   class RegistrationsController < Devise::RegistrationsController
+    before_action :configure_permitted_parameters
     def new
       return super if Settings.devise.account_signup
       redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
@@ -8,6 +9,11 @@ module Hyku
     def create
       return super if Settings.devise.account_signup
       redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
+    end
+
+    private
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:display_name])
     end
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,6 +5,7 @@
         <%= f.error_notification %>
 
         <div class="form-inputs">
+            <%= f.input :display_name, required: true, wrapper: :inline %>
             <%= f.input :email, required: true, autofocus: true, wrapper: :inline %>
             <%= f.input :password, required: true, wrapper: :inline %>
             <%= f.input :password_confirmation, required: true, wrapper: :inline %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -35,6 +35,7 @@ en:
         per: 'Show'
       user:
         email: 'Email address'
+        display_name: 'Your Name'  #add this to other languages
     #   defaults:
     #     password: 'Password'
     #   user:


### PR DESCRIPTION
With reference to: "Contact form name field auto-populates with email address instead of name." on [UP-Hyku test plan](https://docs.google.com/spreadsheets/d/1l_ywidtmzV2jQ29D0IqOnuJf0kiVJr1SFDjTnVIJ-ec/edit?usp=sharing).

This adds a "Name" field when users sign up, which in turn allows the "Contact Form" to display a user name instead of an email address.