### PR TITLE
add License to main fields for 'Add New Work' page

### DIFF
--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -9,5 +9,12 @@ module Hyrax
     def secondary_terms
       super - [:rendering_ids]
     end
+
+    # overrides Hyrax::Forms::WorkForm
+    # to display 'license' in the 'base-terms' div on the user dashboard ‘Add New Work’ description
+    # by getting iterated over in hyrax/app/views/hyrax/base/_form_metadata.html.erb
+    def primary_terms
+      super + [:license]
+    end
   end
 end


### PR DESCRIPTION
Solves "Creative Commons licences would be better in the top default section of the submission." from [UP-Hyku test plan](https://docs.google.com/spreadsheets/d/1l_ywidtmzV2jQ29D0IqOnuJf0kiVJr1SFDjTnVIJ-ec/edit?usp=sharing)

