### PR TITLE
add 'license' to primary_terms applied to both Generic Work and Image

### DIFF
--- a/app/forms/hyrax/form_terms.rb
+++ b/app/forms/hyrax/form_terms.rb
@@ -1,0 +1,11 @@
+module Hyrax
+  module FormTerms
+    include Hyrax::Forms
+    # overrides Hyrax::Forms::WorkForm
+    # to display 'license' in the 'base-terms' div on the user dashboard ‘Add New Work’ description
+    # by getting iterated over in hyrax/app/views/hyrax/base/_form_metadata.html.erb
+    def primary_terms
+      super + [:license]
+    end
+  end
+end

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -2,19 +2,13 @@
 #  `rails generate curation_concerns:work GenericWork`
 module Hyrax
   class GenericWorkForm < Hyrax::Forms::WorkForm
+    include Hyrax::FormTerms
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
     self.terms += [:resource_type, :rendering_ids]
 
     def secondary_terms
       super - [:rendering_ids]
-    end
-
-    # overrides Hyrax::Forms::WorkForm
-    # to display 'license' in the 'base-terms' div on the user dashboard ‘Add New Work’ description
-    # by getting iterated over in hyrax/app/views/hyrax/base/_form_metadata.html.erb
-    def primary_terms
-      super + [:license]
     end
   end
 end

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work Image`
 module Hyrax
   class ImageForm < Hyrax::Forms::WorkForm
+    include Hyrax::FormTerms
     self.model_class = ::Image
     self.terms += [:resource_type, :extent, :rendering_ids]
 


### PR DESCRIPTION
License field now shows both on Generic Work and Image creation forms.