### PR TITLE
Change to Logo color when hovering

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -12,6 +12,9 @@
   }
 }
 
+.navbar-inverse .navbar-brand:hover, .navbar-inverse .navbar-nav > li > a:hover {
+  color: #bababa;
+}
 
 .jumbotron {
   background: image_url('white-cloud-background.jpg') repeat-x;


### PR DESCRIPTION
Override Bootstrap default color on hover from white to a grey - so if we style the navbar in white the Institution's name does not seem to disappear.

Trello card [#2576](https://trello.com/c/TbMnba2M)