### PR TITLE
Enable creation of metadata-only records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,3 +42,5 @@ ADD . /data
 RUN bundle exec rake assets:precompile
 
 EXPOSE 3000
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -54,6 +54,10 @@ module Hyku
       solr_document['has_model_ssim'].first
     end
 
+    def readable_model
+      model.split(/(?=[A-Z])/).join(' ')
+    end
+
     def no_associated_file?
       return true if solr_document['file_set_ids_ssim'].blank?
       false

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -50,6 +50,19 @@ module Hyku
       isbns.flatten.compact if isbns
     end
 
+    def model
+      solr_document['has_model_ssim'].first
+    end
+
+    def no_associated_file?
+      return true if solr_document['file_set_ids_ssim'].blank?
+      false
+    end
+
+    def edit_access
+      solr_document['edit_access_person_ssim']
+    end
+
     private
 
       def extract_from_identifier(rgx)
@@ -95,8 +108,6 @@ module Hyku
       # @return [Array] required fields
       def metadata_fields
         ns = "Hyrax"
-        model = solr_document['has_model_ssim'].first
-
         "#{ns}::#{model}Form".constantize.required_fields
       rescue StandardError
         []

--- a/app/views/hyrax/base/_when_no_file.html.erb
+++ b/app/views/hyrax/base/_when_no_file.html.erb
@@ -1,0 +1,5 @@
+<% if presenter.no_associated_file? %>
+  <% if !current_user || (current_user && presenter.edit_access.exclude?(current_user.email)) %>
+    <p>This <%= presenter.model %> has no files associated with it.</p>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/base/_when_no_file.html.erb
+++ b/app/views/hyrax/base/_when_no_file.html.erb
@@ -1,5 +1,5 @@
 <% if presenter.no_associated_file? %>
   <% if !current_user || (current_user && presenter.edit_access.exclude?(current_user.email)) %>
-    <p>This <%= presenter.model %> has no files associated with it.</p>
+    <p>This <%= presenter.readable_model %> has no files associated with it.</p>
   <% end %>
 <% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -26,6 +26,7 @@
 <div class="row">
   <div class="col-sm-12">
     <%= render 'items', presenter: @presenter %>
+    <%= render 'when_no_file', presenter: @presenter %>
     <%= render 'workflow_actions_widget', presenter: @presenter %>
     <%# TODO: we may consider adding these partials in the future %>
     <%#= render 'sharing_with', presenter: @presenter %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -102,7 +102,7 @@ Hyrax.config do |config|
   # Should work creation require file upload, or can a work be created first
   # and a file added at a later time?
   # The default is true.
-  # config.work_requires_files = true
+  config.work_requires_files = false
 
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
   # config.display_share_button_when_not_logged_in = true

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -102,7 +102,7 @@ Hyrax.config do |config|
   # Should work creation require file upload, or can a work be created first
   # and a file added at a later time?
   # The default is true.
-  config.work_requires_files = false
+  # config.work_requires_files = true
 
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
   # config.display_share_button_when_not_logged_in = true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Configure files requirement when creating a work
+if ! grep -F "config.work_requires_files = false" config/initializers/hyrax.rb
+then
+  sed -i -e "105a\ config.work_requires_files = $WORK_REQUIRES_FILES" config/initializers/hyrax.rb
+fi
+
+# Start server
+rm -f tmp/pids/server.pid && bundle exec rails server -p 3000 -b '0.0.0.0'
+
+# Start sidekiq
+bundle exec sidekiq
+
+# zookeeper
+bundle exec rails zookeeper:upload

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :dataset do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    after(:build) do |dataset, evaluator|
+      dataset.apply_depositor_metadata(evaluator.user)
+    end
+  end
+end

--- a/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
@@ -135,4 +135,33 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
       end
     end
   end
+
+  describe "#model" do
+    let(:dataset) { FactoryGirl.build(:dataset) }
+    let(:solr_document) { SolrDocument.new(dataset.to_solr) }
+
+    it "returns the model name" do
+      expect(presenter.model).to eq("Dataset")
+    end
+  end
+
+  describe "#no_associated_file?" do
+    it "returns false if a work has a file set" do
+      expect(presenter.no_associated_file?).to be false
+    end
+
+    it "returns true if a work does not have a file set" do
+      work_with_no_file = FactoryGirl.create(:work)
+      solr_document2 = SolrDocument.new(work_with_no_file.to_solr)
+      presenter2 = described_class.new(solr_document2, nil)
+      expect(presenter2.no_associated_file?).to be true
+    end
+  end
+
+  describe "#edit_access" do
+    it "returns the user who can edit the work" do
+      editor = solr_document['edit_access_person_ssim']
+      expect(presenter.edit_access).to eq(editor)
+    end
+  end
 end


### PR DESCRIPTION
Our Trello card [#2632](https://trello.com/c/mqJYjxlq)

Changes proposed in this pull request:
* Files are no longer `required` to create a work (but can still be added);
* Users see a message indicating if a work does not have any associated file - for works they are allowed to see and not edit.

The message displays under "Items" see below:
![view](https://user-images.githubusercontent.com/26539307/43087133-febe0394-8e96-11e8-9e1d-c947cd259a6f.png)
