### PR TITLE
Automatic migration when launching the app and ability to create account 

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -103,6 +103,7 @@ Hyrax.config do |config|
   # The default is true.
   # config.work_requires_files = true
 
+ config.work_requires_files = false
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
   # config.display_share_button_when_not_logged_in = true
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,11 +6,13 @@ then
   sed -i -e "105a\ config.work_requires_files = $WORK_REQUIRES_FILES" config/initializers/hyrax.rb
 fi
 
+# zookeeper
+bundle exec rails zookeeper:upload
+
+
 # Start server
-rm -f tmp/pids/server.pid && bundle exec rails server -p 3000 -b '0.0.0.0'
+rm -f tmp/pids/server.pid && bundle exec rails db:migrate && bundle exec rails server -p 3000 -b '0.0.0.0'
 
 # Start sidekiq
 bundle exec sidekiq
 
-# zookeeper
-bundle exec rails zookeeper:upload


### PR DESCRIPTION
1. Enable migration  to run automatically. 
 I change this line in docker-entrypoint.sh to include a call rails db:migrate. So the new line is this: rm -f tmp/pids/server.pid && bundle exec rails db:migrate && bundle exec rails server -p 3000 -b '0.0.0.0'

2.  Resolved inability to create account after launching
 We  were not calling zookeeper:upload at the right time.  Now  zookeeper:upload is called before rails migration and bundle exec sidekiq in docker-entrypoint.sh