### PR TITLE
Journal Article metadata template

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -73,6 +73,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
     config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
     config.add_index_field solr_name("keyword", :stored_searchable), itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
+    config.add_index_field solr_name("journal_title", :stored_searchable), label: "Journal Title", link_to_search: solr_name("journal_title", :facetable)
     config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable)
     config.add_index_field solr_name("creator", :stored_searchable), itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
@@ -99,12 +100,19 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("fndr_project_ref", :stored_searchable), label: "Funder project reference"
     config.add_index_field solr_name("add_info", :stored_searchable), label: "Additional information"
     config.add_index_field solr_name("date_accepted", :stored_searchable), label: "Date Accepted"
+    config.add_index_field solr_name("issue", :stored_searchable), label: "Issue"
+    config.add_index_field solr_name("volume", :stored_searchable), label: "Volume"
+    config.add_index_field solr_name("pagination", :stored_searchable), label: "Pagination"
+    config.add_index_field solr_name("article_num", :stored_searchable), label: "Article number"
+    config.add_index_field solr_name("project_name", :stored_searchable), label: "Project Name"
+    config.add_index_field solr_name("rights_holder", :stored_searchable), label: "Rights holder"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field solr_name("title", :stored_searchable)
     config.add_show_field solr_name("description", :stored_searchable)
     config.add_show_field solr_name("keyword", :stored_searchable)
+    config.add_show_field solr_name("journal_title", :stored_searchable)
     config.add_show_field solr_name("subject", :stored_searchable)
     config.add_show_field solr_name("creator", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)
@@ -128,6 +136,12 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("fndr_project_ref", :stored_searchable)
     config.add_show_field solr_name("add_info", :stored_searchable)
     config.add_show_field solr_name("date_accepted", :stored_searchable)
+    config.add_show_field solr_name("issue", :stored_searchable)
+    config.add_show_field solr_name("volume", :stored_searchable)
+    config.add_show_field solr_name("pagination", :stored_searchable)
+    config.add_show_field solr_name("article_num", :stored_searchable)
+    config.add_show_field solr_name("project_name", :stored_searchable)
+    config.add_show_field solr_name("rights_holder", :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -81,6 +81,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
     config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
     config.add_index_field solr_name("publisher", :stored_searchable), itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
+    config.add_index_field solr_name("date_published", :stored_searchable), label: "Date Published"
     config.add_index_field solr_name("based_near_label", :stored_searchable), itemprop: 'contentLocation', link_to_search: solr_name("based_near_label", :facetable)
     config.add_index_field solr_name("language", :stored_searchable), itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
     config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
@@ -94,6 +95,10 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
     config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
     config.add_index_field solr_name("org_unit", :stored_searchable), label: "Organisational Unit"
+    config.add_index_field solr_name("funder", :stored_searchable), label: "Funder"
+    config.add_index_field solr_name("fndr_project_ref", :stored_searchable), label: "Funder project reference"
+    config.add_index_field solr_name("add_info", :stored_searchable), label: "Additional information"
+    config.add_index_field solr_name("date_accepted", :stored_searchable), label: "Date Accepted"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -104,6 +109,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("creator", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)
     config.add_show_field solr_name("publisher", :stored_searchable)
+    config.add_show_field solr_name("date_published", :stored_searchable)
     config.add_show_field solr_name("based_near_label", :stored_searchable)
     config.add_show_field solr_name("language", :stored_searchable)
     config.add_show_field solr_name("date_uploaded", :stored_searchable)
@@ -118,6 +124,10 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("institution", :stored_searchable)
     config.add_show_field solr_name("org_unit", :stored_searchable)
     config.add_show_field solr_name("refereed", :stored_searchable)
+    config.add_show_field solr_name("funder", :stored_searchable)
+    config.add_show_field solr_name("fndr_project_ref", :stored_searchable)
+    config.add_show_field solr_name("add_info", :stored_searchable)
+    config.add_show_field solr_name("date_accepted", :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -117,6 +117,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name('extent', :stored_searchable)
     config.add_show_field solr_name("institution", :stored_searchable)
     config.add_show_field solr_name("org_unit", :stored_searchable)
+    config.add_show_field solr_name("refereed", :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -79,6 +79,9 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     config.add_index_field solr_name("isni", :stored_searchable), label: "ISNI"
     config.add_index_field solr_name("institution", :stored_searchable), label: "Institution"
+    config.add_index_field solr_name("doi", :stored_searchable), label: "DOI"
+    config.add_index_field solr_name("issn", :stored_searchable), label: "ISSN"
+    config.add_index_field solr_name("eissn", :stored_searchable), label: "eISSN"
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
     config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
     config.add_index_field solr_name("publisher", :stored_searchable), itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
@@ -105,6 +108,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("pagination", :stored_searchable), label: "Pagination"
     config.add_index_field solr_name("article_num", :stored_searchable), label: "Article number"
     config.add_index_field solr_name("project_name", :stored_searchable), label: "Project Name"
+    config.add_index_field solr_name("official_link", :stored_searchable), label: "Official link"
     config.add_index_field solr_name("rights_holder", :stored_searchable), label: "Rights holder"
 
     # solr fields to be displayed in the show (single result) view
@@ -128,6 +132,9 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("resource_type", :stored_searchable), label: "Resource Type"
     config.add_show_field solr_name("format", :stored_searchable)
     config.add_show_field solr_name("identifier", :stored_searchable)
+    config.add_show_field solr_name("doi", :stored_searchable)
+    config.add_show_field solr_name("issn", :stored_searchable)
+    config.add_show_field solr_name("eissn", :stored_searchable)
     config.add_show_field solr_name('extent', :stored_searchable)
     config.add_show_field solr_name("institution", :stored_searchable)
     config.add_show_field solr_name("org_unit", :stored_searchable)
@@ -141,6 +148,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("pagination", :stored_searchable)
     config.add_show_field solr_name("article_num", :stored_searchable)
     config.add_show_field solr_name("project_name", :stored_searchable)
+    config.add_show_field solr_name("official_link", :stored_searchable)
     config.add_show_field solr_name("rights_holder", :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,6 +77,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("creator", :stored_searchable), itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     config.add_index_field solr_name("isni", :stored_searchable), label: "ISNI"
+    config.add_index_field solr_name("institution", :stored_searchable), label: "Institution"
     config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
     config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
     config.add_index_field solr_name("publisher", :stored_searchable), itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
@@ -92,6 +93,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("identifier", :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
     config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
     config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
+    config.add_index_field solr_name("org_unit", :stored_searchable), label: "Organisational Unit"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -113,6 +115,8 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("format", :stored_searchable)
     config.add_show_field solr_name("identifier", :stored_searchable)
     config.add_show_field solr_name('extent', :stored_searchable)
+    config.add_show_field solr_name("institution", :stored_searchable)
+    config.add_show_field solr_name("org_unit", :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/decorators/models/basic_metadata_decorator.rb
+++ b/app/decorators/models/basic_metadata_decorator.rb
@@ -30,6 +30,12 @@ module Hyrax
       property :date_submitted, predicate: ::RDF::Vocab::DC.dateSubmitted, multiple: false do |index|
         index.as :stored_searchable
       end
+      property :project_name, predicate: ::RDF::Vocab::BF2.term(:CollectiveTitle), multiple: false do |index|
+        index.as :stored_searchable
+      end
+      property :rights_holder, predicate: ::RDF::Vocab::DC.rightsHolder, multiple: false do |index|
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/decorators/models/basic_metadata_decorator.rb
+++ b/app/decorators/models/basic_metadata_decorator.rb
@@ -1,7 +1,8 @@
 module Hyrax
   module BasicMetadataDecorator
     extend ActiveSupport::Concern
-
+    # include here properties (fields) shared across all templates
+    # also see SharedMetadata
     included do
       property :institution, predicate: ::RDF::Vocab::ORG.organization do |index|
         index.as :stored_searchable

--- a/app/decorators/models/basic_metadata_decorator.rb
+++ b/app/decorators/models/basic_metadata_decorator.rb
@@ -12,6 +12,24 @@ module Hyrax
       property :refereed, predicate: ::RDF::Vocab::BIBO.term("status/peerReviewed") do |index|
         index.as :stored_searchable
       end
+      property :funder, predicate: ::RDF::Vocab::MARCRelators.fnd do |index|
+        index.as :stored_searchable
+      end
+      property :fndr_project_ref, predicate: ::RDF::Vocab::BF2.awards do |index|
+        index.as :stored_searchable
+      end
+      property :add_info, predicate: ::RDF::Vocab::BIBO.term(:Note), multiple: false do |index|
+        index.as :stored_searchable
+      end
+      property :date_published, predicate: ::RDF::Vocab::DC.available, multiple: false do |index|
+        index.as :stored_searchable
+      end
+      property :date_accepted, predicate: ::RDF::Vocab::DC.dateAccepted, multiple: false do |index|
+        index.as :stored_searchable
+      end
+      property :date_submitted, predicate: ::RDF::Vocab::DC.dateSubmitted, multiple: false do |index|
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/decorators/models/basic_metadata_decorator.rb
+++ b/app/decorators/models/basic_metadata_decorator.rb
@@ -6,11 +6,9 @@ module Hyrax
       property :institution, predicate: ::RDF::Vocab::ORG.organization do |index|
         index.as :stored_searchable
       end
-
       property :org_unit, predicate: ::RDF::Vocab::ORG.OrganizationalUnit do |index|
         index.as :stored_searchable
       end
-
       property :refereed, predicate: ::RDF::Vocab::BIBO.term("status/peerReviewed") do |index|
         index.as :stored_searchable
       end

--- a/app/decorators/models/basic_metadata_decorator.rb
+++ b/app/decorators/models/basic_metadata_decorator.rb
@@ -10,6 +10,10 @@ module Hyrax
       property :org_unit, predicate: ::RDF::Vocab::ORG.OrganizationalUnit do |index|
         index.as :stored_searchable
       end
+
+      property :refereed, predicate: ::RDF::Vocab::BIBO.term("status/peerReviewed") do |index|
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/decorators/models/basic_metadata_decorator.rb
+++ b/app/decorators/models/basic_metadata_decorator.rb
@@ -1,0 +1,15 @@
+module Hyrax
+  module BasicMetadataDecorator
+    extend ActiveSupport::Concern
+
+    included do
+      property :institution, predicate: ::RDF::Vocab::ORG.organization do |index|
+        index.as :stored_searchable
+      end
+
+      property :org_unit, predicate: ::RDF::Vocab::ORG.OrganizationalUnit do |index|
+        index.as :stored_searchable
+      end
+    end
+  end
+end

--- a/app/decorators/models/basic_metadata_decorator.rb
+++ b/app/decorators/models/basic_metadata_decorator.rb
@@ -37,6 +37,9 @@ module Hyrax
       property :rights_holder, predicate: ::RDF::Vocab::DC.rightsHolder, multiple: false do |index|
         index.as :stored_searchable
       end
+      property :doi, predicate: ::RDF::Vocab::BIBO.doi, multiple: false do |index|
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/forms/hyrax/book_contribution_form.rb
+++ b/app/forms/hyrax/book_contribution_form.rb
@@ -4,6 +4,6 @@ module Hyrax
   class BookContributionForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::BookContribution
-    self.terms += %i[resource_type rendering_ids institution org_unit]
+    self.terms += %i[resource_type rendering_ids institution org_unit refereed]
   end
 end

--- a/app/forms/hyrax/book_contribution_form.rb
+++ b/app/forms/hyrax/book_contribution_form.rb
@@ -4,6 +4,6 @@ module Hyrax
   class BookContributionForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::BookContribution
-    self.terms += %i[resource_type rendering_ids]
+    self.terms += %i[resource_type rendering_ids institution org_unit]
   end
 end

--- a/app/forms/hyrax/book_form.rb
+++ b/app/forms/hyrax/book_form.rb
@@ -4,6 +4,6 @@ module Hyrax
   class BookForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Book
-    self.terms += %i[resource_type rendering_ids institution org_unit]
+    self.terms += %i[resource_type rendering_ids institution org_unit refereed]
   end
 end

--- a/app/forms/hyrax/book_form.rb
+++ b/app/forms/hyrax/book_form.rb
@@ -4,6 +4,6 @@ module Hyrax
   class BookForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Book
-    self.terms += %i[resource_type rendering_ids]
+    self.terms += %i[resource_type rendering_ids institution org_unit]
   end
 end

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -2,6 +2,6 @@ module Hyrax
   class ConferenceItemForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::ConferenceItem
-    self.terms += %i[resource_type rendering_ids]
+    self.terms += %i[resource_type rendering_ids institution org_unit]
   end
 end

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -2,6 +2,6 @@ module Hyrax
   class ConferenceItemForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::ConferenceItem
-    self.terms += %i[resource_type rendering_ids institution org_unit]
+    self.terms += %i[resource_type rendering_ids institution org_unit refereed]
   end
 end

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class DatasetForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Dataset
-    self.terms += %i[resource_type rendering_ids isni]
+    self.terms += %i[resource_type rendering_ids isni institution org_unit]
     self.required_fields += [:isni]
   end
 end

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class DatasetForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Dataset
-    self.terms += %i[resource_type rendering_ids isni institution org_unit]
+    self.terms += %i[resource_type rendering_ids isni institution org_unit refereed]
     self.required_fields += [:isni]
   end
 end

--- a/app/forms/hyrax/form_terms.rb
+++ b/app/forms/hyrax/form_terms.rb
@@ -4,9 +4,9 @@ module Hyrax
     # overrides Hyrax::Forms::WorkForm
     # to display 'license' in the 'base-terms' div on the user dashboard "Add New Work" description
     # by getting iterated over in hyrax/app/views/hyrax/base/_form_metadata.html.erb
-    def primary_terms
-      super + [:license]
-    end
+    # def primary_terms
+    #   super + [:license]
+    # end
 
     def secondary_terms
       super - %i[rendering_ids date_created identifier]

--- a/app/forms/hyrax/form_terms.rb
+++ b/app/forms/hyrax/form_terms.rb
@@ -9,7 +9,7 @@ module Hyrax
     end
 
     def secondary_terms
-      super - [:rendering_ids]
+      super - [:rendering_ids, :date_created]
     end
   end
 end

--- a/app/forms/hyrax/form_terms.rb
+++ b/app/forms/hyrax/form_terms.rb
@@ -9,7 +9,7 @@ module Hyrax
     end
 
     def secondary_terms
-      super - [:rendering_ids, :date_created]
+      super - %i[rendering_ids date_created identifier]
     end
   end
 end

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -4,9 +4,10 @@ module Hyrax
   class JournalArticleForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::JournalArticle
-    self.terms += %i[resource_type rendering_ids institution org_unit refereed official_link funder fndr_project_ref
-                     add_info date_published date_accepted date_submitted journal_title issue volume
-                     pagination article_num project_name rights_holder doi issn eissn]
-    self.required_fields += %i[journal_title date_published]
+    self.terms += %i[resource_type rendering_ids journal_title doi volume issue pagination issn eissn
+                     article_num date_published date_accepted date_submitted institution org_unit refereed
+                     official_link project_name funder fndr_project_ref add_info rights_holder]
+    self.required_fields += %i[journal_title institution publisher date_published]
+    self.required_fields -= %i[keyword rights_statement]
   end
 end

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -4,9 +4,9 @@ module Hyrax
   class JournalArticleForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::JournalArticle
-    self.terms += %i[resource_type rendering_ids institution org_unit refereed funder fndr_project_ref
+    self.terms += %i[resource_type rendering_ids institution org_unit refereed official_link funder fndr_project_ref
                      add_info date_published date_accepted date_submitted journal_title issue volume
-                     pagination article_num project_name rights_holder]
+                     pagination article_num project_name rights_holder doi issn eissn]
     self.required_fields += %i[journal_title date_published]
   end
 end

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -4,6 +4,6 @@ module Hyrax
   class JournalArticleForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::JournalArticle
-    self.terms += %i[resource_type rendering_ids institution org_unit]
+    self.terms += %i[resource_type rendering_ids institution org_unit refereed]
   end
 end

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -4,6 +4,6 @@ module Hyrax
   class JournalArticleForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::JournalArticle
-    self.terms += %i[resource_type rendering_ids]
+    self.terms += %i[resource_type rendering_ids institution org_unit]
   end
 end

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -5,7 +5,8 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::JournalArticle
     self.terms += %i[resource_type rendering_ids institution org_unit refereed funder fndr_project_ref
-                     add_info date_published date_accepted date_submitted]
-    self.required_fields += [:date_published]
+                     add_info date_published date_accepted date_submitted journal_title issue volume
+                     pagination article_num project_name rights_holder]
+    self.required_fields += %i[journal_title date_published]
   end
 end

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -4,6 +4,8 @@ module Hyrax
   class JournalArticleForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::JournalArticle
-    self.terms += %i[resource_type rendering_ids institution org_unit refereed]
+    self.terms += %i[resource_type rendering_ids institution org_unit refereed funder fndr_project_ref
+                     add_info date_published date_accepted date_submitted]
+    self.required_fields += [:date_published]
   end
 end

--- a/app/forms/hyrax/report_form.rb
+++ b/app/forms/hyrax/report_form.rb
@@ -4,6 +4,6 @@ module Hyrax
   class ReportForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Report
-    self.terms += %i[resource_type rendering_ids]
+    self.terms += %i[resource_type rendering_ids institution org_unit]
   end
 end

--- a/app/forms/hyrax/report_form.rb
+++ b/app/forms/hyrax/report_form.rb
@@ -4,6 +4,6 @@ module Hyrax
   class ReportForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Report
-    self.terms += %i[resource_type rendering_ids institution org_unit]
+    self.terms += %i[resource_type rendering_ids institution org_unit refereed]
   end
 end

--- a/app/models/concerns/ubiquity/shared_metadata.rb
+++ b/app/models/concerns/ubiquity/shared_metadata.rb
@@ -9,5 +9,14 @@ module SharedMetadata
     property :pagination, predicate: ::RDF::Vocab::BIBO.numPages, multiple: false do |index|
       index.as :stored_searchable
     end
+    property :issn, predicate: ::RDF::Vocab::BIBO.issn, multiple: false do |index|
+      index.as :stored_searchable
+    end
+    property :eissn, predicate: ::RDF::Vocab::BIBO.eissn, multiple: false do |index|
+      index.as :stored_searchable
+    end
+    property :official_link, predicate: ::RDF::Vocab::SCHEMA.url, multiple: false do |index|
+      index.as :stored_searchable
+    end
   end
 end

--- a/app/models/concerns/ubiquity/shared_metadata.rb
+++ b/app/models/concerns/ubiquity/shared_metadata.rb
@@ -1,0 +1,13 @@
+module SharedMetadata
+  extend ActiveSupport::Concern
+  # include here properties (fields) shared across a number of templates but not all
+  # also see BasicMetadataDecorator
+  included do
+    property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
+      index.as :stored_searchable
+    end
+    property :pagination, predicate: ::RDF::Vocab::BIBO.numPages, multiple: false do |index|
+      index.as :stored_searchable
+    end
+  end
+end

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -11,6 +11,22 @@ class JournalArticle < ActiveFedora::Base
 
   self.human_readable_type = 'Journal Article'
 
+  property :issue, predicate: ::RDF::Vocab::Bibframe.term(:Serial), multiple: false do |index|
+    index.as :stored_searchable
+  end
+  property :journal_title, predicate: ::RDF::Vocab::BIBO.Journal do |index|
+    index.as :stored_searchable, :facetable
+  end
+  property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
+    index.as :stored_searchable
+  end
+  property :pagination, predicate: ::RDF::Vocab::BIBO.numPages, multiple: false do |index|
+    index.as :stored_searchable
+  end
+  property :article_num, predicate: ::RDF::Vocab::BIBO.number, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -3,6 +3,7 @@
 class JournalArticle < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include Hyrax::BasicMetadataDecorator
+  include SharedMetadata
 
   self.indexer = JournalArticleIndexer
   # Change this to restrict which works can be added as a child.
@@ -16,12 +17,6 @@ class JournalArticle < ActiveFedora::Base
   end
   property :journal_title, predicate: ::RDF::Vocab::BIBO.Journal do |index|
     index.as :stored_searchable, :facetable
-  end
-  property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
-    index.as :stored_searchable
-  end
-  property :pagination, predicate: ::RDF::Vocab::BIBO.numPages, multiple: false do |index|
-    index.as :stored_searchable
   end
   property :article_num, predicate: ::RDF::Vocab::BIBO.number, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -2,6 +2,7 @@
 #  `rails generate hyrax:work JournalArticle`
 class JournalArticle < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include Hyrax::BasicMetadataDecorator
 
   self.indexer = JournalArticleIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -31,4 +31,10 @@ class SolrDocument
   attribute :institution, Solr::Array, solr_name('institution')
   attribute :org_unit, Solr::Array, solr_name('org_unit')
   attribute :refereed, Solr::Array, solr_name('refereed')
+  attribute :funder, Solr::Array, solr_name('funder')
+  attribute :fndr_project_ref, Solr::Array, solr_name('fndr_project_ref')
+  attribute :add_info, Solr::Array, solr_name('add_info')
+  attribute :date_published, Solr::Array, solr_name('date_published')
+  attribute :date_accepted, Solr::Array, solr_name('date_accepted')
+  attribute :date_submitted, Solr::Array, solr_name('date_submitted')
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -44,4 +44,8 @@ class SolrDocument
   attribute :article_num, Solr::Array, solr_name('article_num')
   attribute :project_name, Solr::Array, solr_name('project_name')
   attribute :rights_holder, Solr::Array, solr_name('rights_holder')
+  attribute :doi, Solr::Array, solr_name('doi')
+  attribute :issn, Solr::Array, solr_name('issn')
+  attribute :eissn, Solr::Array, solr_name('eissn')
+  attribute :official_link, Solr::Array, solr_name('official_link')
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -28,4 +28,7 @@ class SolrDocument
   attribute :extent, Solr::Array, solr_name('extent')
   attribute :rendering_ids, Solr::Array, solr_name('hasFormat', :symbol)
   attribute :isni, Solr::Array, solr_name('isni')
+  attribute :institution, Solr::Array, solr_name('institution')
+  attribute :org_unit, Solr::Array, solr_name('org_unit')
+  attribute :refereed, Solr::Array, solr_name('refereed')
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -37,4 +37,11 @@ class SolrDocument
   attribute :date_published, Solr::Array, solr_name('date_published')
   attribute :date_accepted, Solr::Array, solr_name('date_accepted')
   attribute :date_submitted, Solr::Array, solr_name('date_submitted')
+  attribute :journal_title, Solr::Array, solr_name('journal_title')
+  attribute :issue, Solr::Array, solr_name('issue')
+  attribute :volume, Solr::Array, solr_name('volume')
+  attribute :pagination, Solr::Array, solr_name('pagination')
+  attribute :article_num, Solr::Array, solr_name('article_num')
+  attribute :project_name, Solr::Array, solr_name('project_name')
+  attribute :rights_holder, Solr::Array, solr_name('rights_holder')
 end

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -2,9 +2,10 @@ module Hyku
   class ManifestEnabledWorkShowPresenter < Hyrax::WorkShowPresenter
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyku::FileSetPresenter
 
-    delegate :extent, :rendering_ids, :isni, :institution, :org_unit, :refereed,
+    delegate :extent, :rendering_ids, :isni, :institution, :org_unit, :refereed, :doi, :issn, :eissn,
              :funder, :fndr_project_ref, :add_info, :date_published, :date_accepted, :date_submitted,
              :journal_title, :issue, :volume, :pagination, :article_num, :project_name, :rights_holder,
+             :official_link,
              to: :solr_document
 
     def manifest_url

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -4,6 +4,7 @@ module Hyku
 
     delegate :extent, :rendering_ids, :isni, :institution, :org_unit, :refereed,
              :funder, :fndr_project_ref, :add_info, :date_published, :date_accepted, :date_submitted,
+             :journal_title, :issue, :volume, :pagination, :article_num, :project_name, :rights_holder,
              to: :solr_document
 
     def manifest_url

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -2,7 +2,9 @@ module Hyku
   class ManifestEnabledWorkShowPresenter < Hyrax::WorkShowPresenter
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyku::FileSetPresenter
 
-    delegate :extent, :rendering_ids, :isni, to: :solr_document
+    delegate :extent, :rendering_ids, :isni, :institution, :org_unit, :refereed,
+             :funder, :fndr_project_ref, :add_info, :date_published, :date_accepted, :date_submitted,
+             to: :solr_document
 
     def manifest_url
       manifest_helper.polymorphic_url([:manifest, self])

--- a/app/services/institution_service.rb
+++ b/app/services/institution_service.rb
@@ -1,0 +1,14 @@
+module InstitutionService
+  mattr_accessor :authority
+  self.authority = Qa::Authorities::Local.subauthority_for('institution')
+
+  def self.select_options
+    authority.all.map do |element|
+      [element[:label], element[:id]]
+    end
+  end
+
+  def self.label(id)
+    authority.find(id).fetch('term')
+  end
+end

--- a/app/services/refereed_service.rb
+++ b/app/services/refereed_service.rb
@@ -1,0 +1,14 @@
+module RefereedService
+  mattr_accessor :authority
+  self.authority = Qa::Authorities::Local.subauthority_for('refereed')
+
+  def self.select_options
+    authority.all.map do |element|
+      [element[:label], element[:id]]
+    end
+  end
+
+  def self.label(id)
+    authority.find(id).fetch('term')
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -14,6 +14,9 @@
 <%= presenter.attribute_to_html(:source) %>
 <%= presenter.attribute_to_html(:rights_statement) %>
 <%= presenter.attribute_to_html(:extent) %>
+<%= presenter.attribute_to_html(:doi) %>
+<%= presenter.attribute_to_html(:issn) %>
+<%= presenter.attribute_to_html(:eissn) %>
 <%= presenter.attribute_to_html(:isni) %>
 <%= presenter.attribute_to_html(:institution) %>
 <%= presenter.attribute_to_html(:org_unit) %> <!-- need to change this rendering-->
@@ -27,4 +30,5 @@
 <%= presenter.attribute_to_html(:pagination) %>
 <%= presenter.attribute_to_html(:article_num) %> <!-- need to change this rendering-->
 <%= presenter.attribute_to_html(:project_name) %>
+<%= presenter.attribute_to_html(:official_link) %>
 <%= presenter.attribute_to_html(:rights_holder) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -2,6 +2,7 @@
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:date_published) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
@@ -14,5 +15,9 @@
 <%= presenter.attribute_to_html(:extent) %>
 <%= presenter.attribute_to_html(:isni) %>
 <%= presenter.attribute_to_html(:institution) %>
-<%= presenter.attribute_to_html(:org_unit) %>
+<%= presenter.attribute_to_html(:org_unit) %> <!-- need to change this rendering-->
 <%= presenter.attribute_to_html(:refereed) %>
+<%= presenter.attribute_to_html(:funder) %>
+<%= presenter.attribute_to_html(:fndr_project_ref) %> <!-- need to change this rendering-->
+<%= presenter.attribute_to_html(:add_info) %> <!-- need to change this rendering-->
+<%= presenter.attribute_to_html(:date_accepted) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,6 +1,7 @@
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:journal_title, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:date_published) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>
@@ -21,3 +22,9 @@
 <%= presenter.attribute_to_html(:fndr_project_ref) %> <!-- need to change this rendering-->
 <%= presenter.attribute_to_html(:add_info) %> <!-- need to change this rendering-->
 <%= presenter.attribute_to_html(:date_accepted) %>
+<%= presenter.attribute_to_html(:volume) %>
+<%= presenter.attribute_to_html(:issue) %>
+<%= presenter.attribute_to_html(:pagination) %>
+<%= presenter.attribute_to_html(:article_num) %> <!-- need to change this rendering-->
+<%= presenter.attribute_to_html(:project_name) %>
+<%= presenter.attribute_to_html(:rights_holder) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -13,3 +13,6 @@
 <%= presenter.attribute_to_html(:rights_statement) %>
 <%= presenter.attribute_to_html(:extent) %>
 <%= presenter.attribute_to_html(:isni) %>
+<%= presenter.attribute_to_html(:institution) %>
+<%= presenter.attribute_to_html(:org_unit) %>
+<%= presenter.attribute_to_html(:refereed) %>

--- a/app/views/records/edit_fields/_institution.html.erb
+++ b/app/views/records/edit_fields/_institution.html.erb
@@ -1,0 +1,3 @@
+<%= f.input :institution, as: :select,
+            collection: InstitutionService.select_options,
+            input_html: { class: 'form-control' } %>

--- a/app/views/records/edit_fields/_refereed.html.erb
+++ b/app/views/records/edit_fields/_refereed.html.erb
@@ -1,0 +1,3 @@
+<%= f.input :refereed, as: :select,
+            collection: RefereedService.select_options,
+            input_html: { class: 'form-control' } %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module Hyku
         require_dependency(c)
       end
       Hyrax::DownloadsController.include ::Hyrax::DownloadsControllerDecorator
+      Hyrax::BasicMetadata.include ::Hyrax::BasicMetadataDecorator
     end
 
     config.before_initialize do

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module Hyku
     # -- all .rb files in that directory are automatically loaded.
 
     require_relative "../app/decorators/models/basic_metadata_decorator"
+    require_relative "../app/models/concerns/ubiquity/shared_metadata"
 
     # Gzip all responses.  We probably could do this in an upstream proxy, but
     # configuring Nginx on Elastic Beanstalk is a pain.

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ module Hyku
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    require_relative "../app/decorators/models/basic_metadata_decorator"
+
     # Gzip all responses.  We probably could do this in an upstream proxy, but
     # configuring Nginx on Elastic Beanstalk is a pain.
     config.middleware.use Rack::Deflater
@@ -36,11 +38,10 @@ module Hyku
       # authenticity token errors.
       Hyrax::Admin::AppearancesController.form_class = AppearanceForm
       Hyrax::FileSetsController.show_presenter = Hyku::FileSetPresenter
-      Dir.glob(Rails.root + "app/decorators/**/*_decorator*.rb").each do |c|
+      Dir.glob(Rails.root + "app/decorators/**/*_decorator.rb").each do |c|
         require_dependency(c)
       end
       Hyrax::DownloadsController.include ::Hyrax::DownloadsControllerDecorator
-      Hyrax::BasicMetadata.include ::Hyrax::BasicMetadataDecorator
     end
 
     config.before_initialize do

--- a/config/authorities/institution.yml
+++ b/config/authorities/institution.yml
@@ -1,0 +1,11 @@
+terms:
+  - id: British Library
+    term: British Library
+  - id: British Museum
+    term: British Museum
+  - id: MOLA
+    term: MOLA
+  - id: National Museums of Scotland
+    term: National Museums of Scotland
+  - id: TATE
+    term: TATE

--- a/config/authorities/refereed.yml
+++ b/config/authorities/refereed.yml
@@ -1,0 +1,5 @@
+terms:
+  - id: Peer-reviewed
+    term: Peer-reviewed
+  - id: Not Peer-reviewed
+    term: Not Peer-reviewed

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -103,6 +103,7 @@ Hyrax.config do |config|
   # The default is true.
   # config.work_requires_files = true
 
+ config.work_requires_files = false
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
   # config.display_share_button_when_not_logged_in = true
 

--- a/config/locales/journal_article.en.yml
+++ b/config/locales/journal_article.en.yml
@@ -18,9 +18,17 @@ en:
         date_published: The date the item was published and made publicly available. You can provide just the year or a more specific date if you have this available.
         date_accepted: The date the item was accepted for publication. For example, this may be when receiving an acceptance letter from a publisher or when the final text has been copyedited and approved. You can provide just the year or a more specific date if you have this available.
         date_submitted: The date the item was submitted for review to the publisher.  You can provide just the year or a more specific date if you have this available.
+        journal_title: Please enter the journal title, e.g. Journal of Eighteenth-Century Studies
+        issue: If this is not the first edition, please specifiy in the format e.g. 1st, 2nd. Leave blank if not required.
+        volume: Please enter the number, e.g. 2, 76. Leave blank if there are no volumes.
+        pagination: Please enter details of the pagination. For a contribution or article, this can be the range of pages e.g. 1-13, for an entire volume it can be the total number of pages.
+        article_num: If there is an article number, e.g. e0183455 (usually found in online-only journals)
+        rights_holder: Please identify the rights holder if different from the creator.
+        project_name: The name of the project the work relates to, where relevant
     labels:
       defaults:
         org_unit: Organisational Unit
         refereed: Peer-reviewed?
         fndr_project_ref: Funder project reference
         add_info: Additional information
+        article_num: Article number

--- a/config/locales/journal_article.en.yml
+++ b/config/locales/journal_article.en.yml
@@ -6,3 +6,11 @@ en:
       journal_article:
         name:               "Journal Article"
         description:        "Articles in peer-reviewed publications that disseminate the results of original research and scholarship."
+  simple_form:
+    hints:
+      defaults:
+        institution: The institution to which the item is affiliated.
+        org_unit: The department, or unit, that the works sits within as per the organisational structure.
+    labels:
+      defaults:
+        org_unit: Organisational Unit

--- a/config/locales/journal_article.en.yml
+++ b/config/locales/journal_article.en.yml
@@ -25,6 +25,10 @@ en:
         article_num: If there is an article number, e.g. e0183455 (usually found in online-only journals)
         rights_holder: Please identify the rights holder if different from the creator.
         project_name: The name of the project the work relates to, where relevant
+        doi: A persistent digital object identifier, if your item already has one then enter this here in the following model e.g. https://doi.org/10.21250/tcq
+        issn: ISSN, International Standard Serial Number. You can enter either the ISSN or the eISSN or both, if available.
+        eissn: eISSN, Electronic International Standard Serial Number. You can enter either the ISSN or the eISSN or both, if available.
+        official_link: Please enter the official URL, e.g. the publisher's link to the item.
     labels:
       defaults:
         org_unit: Organisational Unit
@@ -32,3 +36,6 @@ en:
         fndr_project_ref: Funder project reference
         add_info: Additional information
         article_num: Article number
+        doi: DOI
+        issn: ISSN
+        eissn: eISSN

--- a/config/locales/journal_article.en.yml
+++ b/config/locales/journal_article.en.yml
@@ -12,7 +12,15 @@ en:
         institution: The institution to which the item is affiliated.
         org_unit: The department, or unit, that the works sits within as per the organisational structure.
         refereed: Please select if the item was peer-reviewed.
+        funder: Use full name e.g. Arts and Humanities Research Council
+        fndr_project_ref: This may be the grant number as allocated by the funding body.
+        add_info: Please enter any additional information here that has not been entered. The information added in this field will be visible to everyone in the public view.
+        date_published: The date the item was published and made publicly available. You can provide just the year or a more specific date if you have this available.
+        date_accepted: The date the item was accepted for publication. For example, this may be when receiving an acceptance letter from a publisher or when the final text has been copyedited and approved. You can provide just the year or a more specific date if you have this available.
+        date_submitted: The date the item was submitted for review to the publisher.  You can provide just the year or a more specific date if you have this available.
     labels:
       defaults:
         org_unit: Organisational Unit
         refereed: Peer-reviewed?
+        fndr_project_ref: Funder project reference
+        add_info: Additional information

--- a/config/locales/journal_article.en.yml
+++ b/config/locales/journal_article.en.yml
@@ -11,6 +11,8 @@ en:
       defaults:
         institution: The institution to which the item is affiliated.
         org_unit: The department, or unit, that the works sits within as per the organisational structure.
+        refereed: Please select if the item was peer-reviewed.
     labels:
       defaults:
         org_unit: Organisational Unit
+        refereed: Peer-reviewed?


### PR DESCRIPTION
Trello card [#2636](https://trello.com/c/M4N5FcIq)

Fields created or adapted:
- Institution
- Organistational Unit
- Peer-reviewed
- Identifier does not display anymore, instead there is: DOI, ISSN, and eISSN
- Funder
- Funder project reference
- Additional info
- Date created doesn not display anymore, instead there is: Date published, Date accepted, and Date submitted
- Journal title
- Issue
- Volume
- Pagination
- Article number
- Project name
- Rights holder
- Official link

More fields to be added

Work In Progress:
- Fields with drop-down lists don't save to database (Peer-reviewed and Institution)
- Some fields display on record views even when empty