### PR TITLE
Additional metadata fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -95,6 +95,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     #config.add_index_field solr_name("isni", :stored_searchable), label: "ISNI"
     config.add_index_field solr_name("institution", :stored_searchable), label: "Institution"
+    config.add_index_field solr_name("series_name", :stored_searchable), label: "Series name", link_to_search: solr_name("series_name", :facetable)
     config.add_index_field solr_name("doi", :stored_searchable), label: "DOI"
     config.add_index_field solr_name("issn", :stored_searchable), label: "ISSN"
     config.add_index_field solr_name("eissn", :stored_searchable), label: "eISSN"
@@ -151,7 +152,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("contributor_isni", :stored_searchable), label: "contributor_isni"
     config.add_show_field solr_name("contributor_organization", :stored_searchable), label: "contributor_organization"
 
-
+    config.add_show_field solr_name("series_name", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)
     config.add_show_field solr_name("publisher", :stored_searchable)
     config.add_show_field solr_name("place_of_publication", :stored_searchable)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -96,6 +96,7 @@ class CatalogController < ApplicationController
     #config.add_index_field solr_name("isni", :stored_searchable), label: "ISNI"
     config.add_index_field solr_name("institution", :stored_searchable), label: "Institution"
     config.add_index_field solr_name("series_name", :stored_searchable), label: "Series name", link_to_search: solr_name("series_name", :facetable)
+    config.add_index_field solr_name("edition", :stored_searchable), label: "Edition"
     config.add_index_field solr_name("doi", :stored_searchable), label: "DOI"
     config.add_index_field solr_name("issn", :stored_searchable), label: "ISSN"
     config.add_index_field solr_name("eissn", :stored_searchable), label: "eISSN"
@@ -153,6 +154,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("contributor_organization", :stored_searchable), label: "contributor_organization"
 
     config.add_show_field solr_name("series_name", :stored_searchable)
+    config.add_show_field solr_name("edition", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)
     config.add_show_field solr_name("publisher", :stored_searchable)
     config.add_show_field solr_name("place_of_publication", :stored_searchable)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -95,6 +95,7 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     #config.add_index_field solr_name("isni", :stored_searchable), label: "ISNI"
     config.add_index_field solr_name("institution", :stored_searchable), label: "Institution"
+    config.add_index_field solr_name("abstract", :stored_searchable), label: "Abstract"
     config.add_index_field solr_name("series_name", :stored_searchable), label: "Series name", link_to_search: solr_name("series_name", :facetable)
     config.add_index_field solr_name("edition", :stored_searchable), label: "Edition"
     config.add_index_field solr_name("doi", :stored_searchable), label: "DOI"
@@ -153,6 +154,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("contributor_isni", :stored_searchable), label: "contributor_isni"
     config.add_show_field solr_name("contributor_organization", :stored_searchable), label: "contributor_organization"
 
+    config.add_show_field solr_name("abstract", :stored_searchable)
     config.add_show_field solr_name("series_name", :stored_searchable)
     config.add_show_field solr_name("edition", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -95,7 +95,10 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
     #config.add_index_field solr_name("isni", :stored_searchable), label: "ISNI"
     config.add_index_field solr_name("institution", :stored_searchable), label: "Institution"
+    config.add_index_field solr_name("event_title", :stored_searchable), label: "Event title", link_to_search: solr_name("event_title", :facetable)
+    config.add_index_field solr_name("event_date", :stored_searchable), label: "Event date"
     config.add_index_field solr_name("abstract", :stored_searchable), label: "Abstract"
+    config.add_index_field solr_name("book_title", :stored_searchable), label: "Book title", link_to_search: solr_name("book_title", :facetable)
     config.add_index_field solr_name("series_name", :stored_searchable), label: "Series name", link_to_search: solr_name("series_name", :facetable)
     config.add_index_field solr_name("edition", :stored_searchable), label: "Edition"
     config.add_index_field solr_name("doi", :stored_searchable), label: "DOI"
@@ -154,7 +157,10 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("contributor_isni", :stored_searchable), label: "contributor_isni"
     config.add_show_field solr_name("contributor_organization", :stored_searchable), label: "contributor_organization"
 
+    config.add_show_field solr_name("event_title", :stored_searchable)
+    config.add_show_field solr_name("event_date", :stored_searchable)
     config.add_show_field solr_name("abstract", :stored_searchable)
+    config.add_show_field solr_name("book_title", :stored_searchable)
     config.add_show_field solr_name("series_name", :stored_searchable)
     config.add_show_field solr_name("edition", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)

--- a/app/forms/hyrax/book_contribution_form.rb
+++ b/app/forms/hyrax/book_contribution_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class BookContributionForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::BookContribution
-    self.terms += %i[resource_type rendering_ids doi series_name volume pagination issn eissn
+    self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination issn eissn
                      date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.required_fields += %i[institution publisher date_published]

--- a/app/forms/hyrax/book_contribution_form.rb
+++ b/app/forms/hyrax/book_contribution_form.rb
@@ -4,9 +4,10 @@ module Hyrax
   class BookContributionForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::BookContribution
-    self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination issn eissn
-                     date_published date_accepted date_submitted institution org_unit refereed
+    self.terms += %i[resource_type rendering_ids doi series_name volume edition place_of_publication pagination
+                     issn eissn date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
+    self.terms -= [:based_near]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/book_contribution_form.rb
+++ b/app/forms/hyrax/book_contribution_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class BookContributionForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::BookContribution
-    self.terms += %i[resource_type rendering_ids doi volume pagination issn eissn
+    self.terms += %i[resource_type rendering_ids doi series_name volume pagination issn eissn
                      date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.required_fields += %i[institution publisher date_published]

--- a/app/forms/hyrax/book_contribution_form.rb
+++ b/app/forms/hyrax/book_contribution_form.rb
@@ -5,9 +5,9 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::BookContribution
     self.terms += %i[resource_type rendering_ids doi series_name volume edition place_of_publication pagination
-                     issn eissn date_published date_accepted date_submitted institution org_unit refereed
+                     issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= [:based_near]
+    self.terms -= %i[based_near description]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/book_form.rb
+++ b/app/forms/hyrax/book_form.rb
@@ -5,9 +5,9 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::Book
     self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination place_of_publication
-                     issn eissn date_published date_accepted date_submitted institution org_unit refereed
+                     issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= [:based_near]
+    self.terms -= %i[based_near description]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/book_form.rb
+++ b/app/forms/hyrax/book_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class BookForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Book
-    self.terms += %i[resource_type rendering_ids doi volume pagination issn eissn
+    self.terms += %i[resource_type rendering_ids doi series_name volume pagination issn eissn
                      date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.required_fields += %i[institution publisher date_published]

--- a/app/forms/hyrax/book_form.rb
+++ b/app/forms/hyrax/book_form.rb
@@ -4,9 +4,10 @@ module Hyrax
   class BookForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Book
-    self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination issn eissn
-                     date_published date_accepted date_submitted institution org_unit refereed
+    self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination place_of_publication
+                     issn eissn date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
+    self.terms -= [:based_near]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/book_form.rb
+++ b/app/forms/hyrax/book_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class BookForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Book
-    self.terms += %i[resource_type rendering_ids doi series_name volume pagination issn eissn
+    self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination issn eissn
                      date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.required_fields += %i[institution publisher date_published]

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -3,9 +3,9 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::ConferenceItem
     self.terms += %i[resource_type rendering_ids doi series_name volume pagination place_of_publication issn eissn
-                     date_published date_accepted date_submitted institution org_unit refereed
+                     date_published date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= [:based_near]
+    self.terms -= %i[based_near description]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -2,9 +2,9 @@ module Hyrax
   class ConferenceItemForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::ConferenceItem
-    self.terms += %i[resource_type rendering_ids doi series_name volume pagination place_of_publication issn eissn
-                     date_published date_accepted date_submitted abstract institution org_unit refereed
-                     project_name funder fndr_project_ref add_info rights_holder]
+    self.terms += %i[resource_type rendering_ids doi event_title event_date book_title series_name volume pagination
+                     place_of_publication issn eissn date_published date_accepted date_submitted abstract institution
+                     org_unit refereed project_name funder fndr_project_ref add_info rights_holder]
     self.terms -= %i[based_near description]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -2,9 +2,10 @@ module Hyrax
   class ConferenceItemForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::ConferenceItem
-    self.terms += %i[resource_type rendering_ids doi series_name volume pagination issn eissn
+    self.terms += %i[resource_type rendering_ids doi series_name volume pagination place_of_publication issn eissn
                      date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
+    self.terms -= [:based_near]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -2,7 +2,7 @@ module Hyrax
   class ConferenceItemForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::ConferenceItem
-    self.terms += %i[resource_type rendering_ids doi volume pagination issn eissn
+    self.terms += %i[resource_type rendering_ids doi series_name volume pagination issn eissn
                      date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.required_fields += %i[institution publisher date_published]

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -5,8 +5,9 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::Dataset
     self.terms += %i[resource_type rendering_ids doi issn eissn
-                     date_published date_accepted date_submitted institution org_unit refereed
+                     date_published place_of_publication date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
+    self.terms -= [:based_near]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -4,10 +4,10 @@ module Hyrax
   class DatasetForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Dataset
-    self.terms += %i[resource_type rendering_ids doi issn eissn
-                     date_published place_of_publication date_accepted date_submitted institution org_unit refereed
+    self.terms += %i[resource_type rendering_ids doi issn eissn date_published place_of_publication
+                     date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= [:based_near]
+    self.terms -= %i[based_near description]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -6,12 +6,12 @@ module Hyrax
     self.model_class = ::JournalArticle
 
     self.terms += %i[resource_type rendering_ids journal_title doi volume issue pagination place_of_publication issn eissn
-                     article_num date_published date_accepted date_submitted institution org_unit refereed
+                     article_num date_published date_accepted date_submitted abstract institution org_unit refereed
                      official_link project_name funder fndr_project_ref add_info rights_holder
                      creator_name_type given_name family_name ORCiD isni creator_organization
                      contributor_type contributor_given_name contributor_family_name contributor_orcid contributor_isni contributor_organization
                      ]
-    self.terms -= [:based_near]
+    self.terms -= %i[based_near description]
     self.required_fields += %i[journal_title institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/report_form.rb
+++ b/app/forms/hyrax/report_form.rb
@@ -5,9 +5,9 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::Report
     self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination place_of_publication
-                     issn eissn date_published date_accepted date_submitted institution org_unit refereed
+                     issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= [:based_near]
+    self.terms -= %i[based_near description]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/forms/hyrax/report_form.rb
+++ b/app/forms/hyrax/report_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class ReportForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Report
-    self.terms += %i[resource_type rendering_ids doi volume pagination issn eissn
+    self.terms += %i[resource_type rendering_ids doi series_name volume pagination issn eissn
                      date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.required_fields += %i[institution publisher date_published]

--- a/app/forms/hyrax/report_form.rb
+++ b/app/forms/hyrax/report_form.rb
@@ -4,7 +4,7 @@ module Hyrax
   class ReportForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Report
-    self.terms += %i[resource_type rendering_ids doi series_name volume pagination issn eissn
+    self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination issn eissn
                      date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.required_fields += %i[institution publisher date_published]

--- a/app/forms/hyrax/report_form.rb
+++ b/app/forms/hyrax/report_form.rb
@@ -4,9 +4,10 @@ module Hyrax
   class ReportForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Report
-    self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination issn eissn
-                     date_published date_accepted date_submitted institution org_unit refereed
+    self.terms += %i[resource_type rendering_ids doi series_name volume edition pagination place_of_publication
+                     issn eissn date_published date_accepted date_submitted institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
+    self.terms -= [:based_near]
     self.required_fields += %i[institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end

--- a/app/models/concerns/ubiquity/basic_metadata_decorator.rb
+++ b/app/models/concerns/ubiquity/basic_metadata_decorator.rb
@@ -93,7 +93,6 @@ module Ubiquity
       property :place_of_publication, predicate: ::RDF::Vocab::BF2.term(:Place) do |index|
         index.as :stored_searchable, :facetable
       end
-
     end
   end
 end

--- a/app/models/concerns/ubiquity/basic_metadata_decorator.rb
+++ b/app/models/concerns/ubiquity/basic_metadata_decorator.rb
@@ -93,6 +93,11 @@ module Ubiquity
       property :place_of_publication, predicate: ::RDF::Vocab::BF2.term(:Place) do |index|
         index.as :stored_searchable, :facetable
       end
+
+      property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
+        index.type :text
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/models/concerns/ubiquity/shared_metadata.rb
+++ b/app/models/concerns/ubiquity/shared_metadata.rb
@@ -1,30 +1,39 @@
 module Ubiquity
-module SharedMetadata
-  extend ActiveSupport::Concern
-  # include here properties (fields) shared across a number of templates but not all
-  # also see BasicMetadataDecorator
-  included do
-    property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
-      index.as :stored_searchable
-    end
-    property :pagination, predicate: ::RDF::Vocab::BIBO.numPages do |index|
-      index.as :stored_searchable
-    end
-    property :issn, predicate: ::RDF::Vocab::BIBO.issn do |index|
-      index.as :stored_searchable
-    end
-    property :eissn, predicate: ::RDF::Vocab::BIBO.eissn do |index|
-      index.as :stored_searchable
-    end
-    property :official_link, predicate: ::RDF::Vocab::SCHEMA.url  do |index|
-      index.as :stored_searchable
-    end
-    property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
-      index.as :stored_searchable, :facetable
-    end
-    property :edition, predicate: ::RDF::Vocab::BF2.edition do |index|
-      index.as :stored_searchable
+  module SharedMetadata
+    extend ActiveSupport::Concern
+    # include here properties (fields) shared across a number of templates but not all
+    # also see BasicMetadataDecorator
+    included do
+      property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
+        index.as :stored_searchable
+      end
+      property :pagination, predicate: ::RDF::Vocab::BIBO.numPages do |index|
+        index.as :stored_searchable
+      end
+      property :issn, predicate: ::RDF::Vocab::BIBO.issn do |index|
+        index.as :stored_searchable
+      end
+      property :eissn, predicate: ::RDF::Vocab::BIBO.eissn do |index|
+        index.as :stored_searchable
+      end
+      property :official_link, predicate: ::RDF::Vocab::SCHEMA.url  do |index|
+        index.as :stored_searchable
+      end
+      property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
+        index.as :stored_searchable, :facetable
+      end
+      property :edition, predicate: ::RDF::Vocab::BF2.edition do |index|
+        index.as :stored_searchable
+      end
+      property :event_title, predicate: ::RDF::Vocab::BF2.term(:Event) do |index|
+        index.as :stored_searchable, :facetable
+      end
+      property :event_date, predicate: ::RDF::Vocab::Bibframe.eventDate do |index|
+        index.as :stored_searchable
+      end
+      property :book_title, predicate: ::RDF::Vocab::BIBO.term(:Proceedings), multiple: false do |index|
+        index.as :stored_searchable, :facetable
+      end
     end
   end
-end
 end

--- a/app/models/concerns/ubiquity/shared_metadata.rb
+++ b/app/models/concerns/ubiquity/shared_metadata.rb
@@ -19,6 +19,9 @@ module SharedMetadata
     property :official_link, predicate: ::RDF::Vocab::SCHEMA.url  do |index|
       index.as :stored_searchable
     end
+    property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
+      index.as :stored_searchable, :facetable
+    end
   end
 end
 end

--- a/app/models/concerns/ubiquity/shared_metadata.rb
+++ b/app/models/concerns/ubiquity/shared_metadata.rb
@@ -22,6 +22,9 @@ module SharedMetadata
     property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
       index.as :stored_searchable, :facetable
     end
+    property :edition, predicate: ::RDF::Vocab::BF2.edition do |index|
+      index.as :stored_searchable
+    end
   end
 end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -64,4 +64,5 @@ class SolrDocument
   attribute :contributor_organization, Solr::Array, solr_name('contributor_organization')
 
   attribute :place_of_publication, Solr::Array, solr_name('place_of_publication')
+  attribute :series_name, Solr::Array, solr_name('series_name')
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -66,4 +66,5 @@ class SolrDocument
   attribute :place_of_publication, Solr::Array, solr_name('place_of_publication')
   attribute :series_name, Solr::Array, solr_name('series_name')
   attribute :edition, Solr::Array, solr_name('edition')
+  attribute :abstract, Solr::Array, solr_name('abstract')
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -67,4 +67,7 @@ class SolrDocument
   attribute :series_name, Solr::Array, solr_name('series_name')
   attribute :edition, Solr::Array, solr_name('edition')
   attribute :abstract, Solr::Array, solr_name('abstract')
+  attribute :event_title, Solr::Array, solr_name('event_title')
+  attribute :event_date, Solr::Array, solr_name('event_date')
+  attribute :book_title, Solr::Array, solr_name('book_title')
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -65,4 +65,5 @@ class SolrDocument
 
   attribute :place_of_publication, Solr::Array, solr_name('place_of_publication')
   attribute :series_name, Solr::Array, solr_name('series_name')
+  attribute :edition, Solr::Array, solr_name('edition')
 end

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -7,7 +7,7 @@ module Hyku
              :journal_title, :issue, :volume, :pagination, :article_num, :project_name, :rights_holder,
              :official_link, :creator_name_type, :given_name, :family_name, :ORCiD, :isni, :creator_organization,
              :contributor_type, :contributor_given_name, :contributor_family_name, :contributor_orcid,
-             :contributor_isni, :contributor_organization, :place_of_publication,
+             :contributor_isni, :contributor_organization, :place_of_publication, :series_name,
              to: :solr_document
 
     def manifest_url

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -8,6 +8,7 @@ module Hyku
              :official_link, :creator_name_type, :given_name, :family_name, :ORCiD, :isni, :creator_organization,
              :contributor_type, :contributor_given_name, :contributor_family_name, :contributor_orcid,
              :contributor_isni, :contributor_organization, :place_of_publication, :series_name, :edition, :abstract,
+             :event_title, :event_date, :book_title,
              to: :solr_document
 
     def manifest_url

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -7,7 +7,7 @@ module Hyku
              :journal_title, :issue, :volume, :pagination, :article_num, :project_name, :rights_holder,
              :official_link, :creator_name_type, :given_name, :family_name, :ORCiD, :isni, :creator_organization,
              :contributor_type, :contributor_given_name, :contributor_family_name, :contributor_orcid,
-             :contributor_isni, :contributor_organization, :place_of_publication, :series_name, :edition,
+             :contributor_isni, :contributor_organization, :place_of_publication, :series_name, :edition, :abstract,
              to: :solr_document
 
     def manifest_url

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -7,7 +7,7 @@ module Hyku
              :journal_title, :issue, :volume, :pagination, :article_num, :project_name, :rights_holder,
              :official_link, :creator_name_type, :given_name, :family_name, :ORCiD, :isni, :creator_organization,
              :contributor_type, :contributor_given_name, :contributor_family_name, :contributor_orcid,
-             :contributor_isni, :contributor_organization, :place_of_publication, :series_name,
+             :contributor_isni, :contributor_organization, :place_of_publication, :series_name, :edition,
              to: :solr_document
 
     def manifest_url

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -49,3 +49,4 @@
 <%= presenter.attribute_to_html(:official_link) %>
 <%= presenter.attribute_to_html(:rights_holder) %>
 <%= presenter.attribute_to_html(:place_of_publication) %>
+<%= presenter.attribute_to_html(:series_name) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -50,3 +50,4 @@
 <%= presenter.attribute_to_html(:rights_holder) %>
 <%= presenter.attribute_to_html(:place_of_publication) %>
 <%= presenter.attribute_to_html(:series_name) %>
+<%= presenter.attribute_to_html(:edition) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -51,3 +51,4 @@
 <%= presenter.attribute_to_html(:place_of_publication) %>
 <%= presenter.attribute_to_html(:series_name) %>
 <%= presenter.attribute_to_html(:edition) %>
+<%= presenter.attribute_to_html(:abstract) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -52,3 +52,6 @@
 <%= presenter.attribute_to_html(:series_name) %>
 <%= presenter.attribute_to_html(:edition) %>
 <%= presenter.attribute_to_html(:abstract) %>
+<%= presenter.attribute_to_html(:event_title) %>
+<%= presenter.attribute_to_html(:event_date) %>
+<%= presenter.attribute_to_html(:book_title) %>

--- a/app/views/records/edit_fields/_abstract.html.erb
+++ b/app/views/records/edit_fields/_abstract.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.multiple? key %>
+  <%= f.input :abstract, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input :abstract, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+<% end %>

--- a/config/locales/book.en.yml
+++ b/config/locales/book.en.yml
@@ -10,3 +10,4 @@ en:
     hints:
       defaults:
         series_name: Please enter the series title, e.g. British Library Research Publications
+        edition: If this is not the first edition, please specifiy in the format e.g. 1st, 2nd. Leave blank if not required.

--- a/config/locales/book.en.yml
+++ b/config/locales/book.en.yml
@@ -6,3 +6,7 @@ en:
       book:
         name:               "Book"
         description:        "Books written by a single author or collaboratively based on research or scholarly findings."
+  simple_form:
+    hints:
+      defaults:
+        series_name: Please enter the series title, e.g. British Library Research Publications

--- a/config/locales/conference_item.en.yml
+++ b/config/locales/conference_item.en.yml
@@ -6,3 +6,10 @@ en:
       conference_item:
         name:               "Conference Item"
         description:        "Papers written alone or collaboratively, presented at an academic conference."
+  simple_form:
+    hints:
+      defaults:
+        event_title: The title of the conference, symposium or other event type.
+        event_date: Please provide the event date or date range in YYYY-MM-DD format, e.g. 2017-11-01 - 2017-11-03, 2017-11, or 2017.
+        book_title: "If published in a separate volume, the title of the Proceedings of which this item is part.\n
+                     If this was published in a journal then use the template 'journal article' instead."

--- a/config/locales/journal_article.en.yml
+++ b/config/locales/journal_article.en.yml
@@ -30,6 +30,7 @@ en:
         eissn: eISSN, Electronic International Standard Serial Number. You can enter either the ISSN or the eISSN or both, if available.
         official_link: Please enter the official URL, e.g. the publisher's link to the item.
         place_of_publication: Enter the town/city and country, or country only, e.g. London, UK or UK
+        abstract: Please provide a short abstract or description of the item.
     labels:
       defaults:
         org_unit: Organisational Unit


### PR DESCRIPTION
More work following PR #20 to #27 
Trello cards [#2636](https://trello.com/c/M4N5FcIq), and [#2662](https://trello.com/c/ITjb2hGv) through [#2666](https://trello.com/c/R8L08tdz)

Global fields added:
- Abstract
- Place of publication

Both of these use different properties than "Abstract or Summary" and "Location" which they replace and get hidden in the forms: `self.terms -= %i[based_near description]`

Non-global fields added:
- Series name, Edition --> to Book, Book contribution, Conference item, and Report templates
- Event title, Event date, Book title --> to Conference Item template