### PR TITLE
[WIP] Metadata: Resource Type custom options per template

### DIFF
--- a/app/forms/hyrax/book_contribution_form.rb
+++ b/app/forms/hyrax/book_contribution_form.rb
@@ -8,7 +8,7 @@ module Hyrax
                      issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.terms -= %i[based_near description]
-    self.required_fields += %i[institution publisher date_published]
+    self.required_fields += %i[resource_type institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end
 end

--- a/app/forms/hyrax/book_form.rb
+++ b/app/forms/hyrax/book_form.rb
@@ -8,7 +8,7 @@ module Hyrax
                      issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.terms -= %i[based_near description]
-    self.required_fields += %i[institution publisher date_published]
+    self.required_fields += %i[resource_type institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end
 end

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -6,7 +6,7 @@ module Hyrax
                      place_of_publication issn eissn date_published date_accepted date_submitted abstract institution
                      org_unit refereed project_name funder fndr_project_ref add_info rights_holder]
     self.terms -= %i[based_near description]
-    self.required_fields += %i[institution publisher date_published]
+    self.required_fields += %i[resource_type institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end
 end

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -8,7 +8,7 @@ module Hyrax
                      date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.terms -= %i[based_near description]
-    self.required_fields += %i[institution publisher date_published]
+    self.required_fields += %i[resource_type institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end
 end

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -6,5 +6,6 @@ module Hyrax
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
     self.terms += %i[resource_type rendering_ids]
+    self.required_fields += [:resource_type]
   end
 end

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -5,5 +5,6 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::Image
     self.terms += %i[resource_type extent rendering_ids]
+    self.required_fields += [:resource_type]
   end
 end

--- a/app/forms/hyrax/journal_article_form.rb
+++ b/app/forms/hyrax/journal_article_form.rb
@@ -12,7 +12,7 @@ module Hyrax
                      contributor_type contributor_given_name contributor_family_name contributor_orcid contributor_isni contributor_organization
                      ]
     self.terms -= %i[based_near description]
-    self.required_fields += %i[journal_title institution publisher date_published]
+    self.required_fields += %i[resource_type journal_title institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end
 end

--- a/app/forms/hyrax/report_form.rb
+++ b/app/forms/hyrax/report_form.rb
@@ -8,7 +8,7 @@ module Hyrax
                      issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
                      project_name funder fndr_project_ref add_info rights_holder]
     self.terms -= %i[based_near description]
-    self.required_fields += %i[institution publisher date_published]
+    self.required_fields += %i[resource_type institution publisher date_published]
     self.required_fields -= %i[keyword rights_statement]
   end
 end

--- a/app/models/concerns/ubiquity/basic_metadata_decorator.rb
+++ b/app/models/concerns/ubiquity/basic_metadata_decorator.rb
@@ -65,10 +65,6 @@ module Ubiquity
         index.as :stored_searchable
       end
 
-      property :contributor_type, predicate: ::RDF::Vocab::DC.type do |index|
-        index.as :stored_searchable
-      end
-
       property :contributor_given_name, predicate: ::RDF::Vocab::SCHEMA.givenName, multiple: false do |index|
         index.as :stored_searchable
       end

--- a/app/renderers/resource_type_renderer.rb
+++ b/app/renderers/resource_type_renderer.rb
@@ -1,0 +1,8 @@
+# retrieve TERM instead of ID to display as documented here:
+# http://samvera.github.io/customize-metadata-show-page.html#write-a-property-specific-custom-renderer
+
+class ResourceTypeAttributeRenderer < Hyrax::Renderers::AttributeRenderer
+  def attribute_value_to_html(value)
+    %(<span itemprop="resource_type">#{::ResourceTypesService.label(value)}</span>)
+  end
+end

--- a/app/services/resource_types_service.rb
+++ b/app/services/resource_types_service.rb
@@ -4,12 +4,20 @@ module ResourceTypesService
   mattr_accessor :authority
   self.authority = Qa::Authorities::Local.subauthority_for('resource_types')
 
+  def self.template_fields(model_class)
+    authority.all.select { |e| e[:id].split.first == model_class.to_s }
+  end
+
   def self.select_template_options(model_class)
-    template_fields = authority.all.select { |e| e[:id].split.first == model_class.to_s }
-    template_fields.map { |t| [t[:label], t[:id]] }
+    template_fields(model_class).map { |t| [t[:label], t[:id]] }
   end
 
   def self.label(id)
     authority.find(id).fetch('term')
+  end
+
+  def self.select_default(model_class)
+    default = template_fields(model_class).select { |e| e[:id].split[1] == 'default' }
+    default.first["id"] if default.present?
   end
 end

--- a/app/services/resource_types_service.rb
+++ b/app/services/resource_types_service.rb
@@ -1,0 +1,15 @@
+# overrides hyrax/app/services/hyrax/resource_types_service.rb
+
+module ResourceTypesService
+  mattr_accessor :authority
+  self.authority = Qa::Authorities::Local.subauthority_for('resource_types')
+
+  def self.select_template_options(model_class)
+    template_fields = authority.all.select { |e| e[:id].split.first == model_class.to_s }
+    template_fields.map { |t| [t[:label], t[:id]] }
+  end
+
+  def self.label(id)
+    authority.find(id).fetch('term')
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -18,6 +18,7 @@
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:journal_title, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:resource_type, render_as: :resource_type) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:date_published) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>
@@ -26,7 +27,6 @@
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim') %>
 <%= presenter.attribute_to_html(:based_near_label) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
-<%= presenter.attribute_to_html(:resource_type, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:source) %>
 <%= presenter.attribute_to_html(:rights_statement) %>
 <%= presenter.attribute_to_html(:extent) %>

--- a/app/views/records/edit_fields/_resource_type.html.erb
+++ b/app/views/records/edit_fields/_resource_type.html.erb
@@ -1,0 +1,5 @@
+<!-- overrides hyrax/app/views/records/edit_fields/_resource_type.html.erb -->
+
+<%= f.input :resource_type, as: :multi_value_select,
+            collection: ResourceTypesService.select_template_options(f.object.model_class),
+            input_html: { class: 'form-control', multiple: true } %>

--- a/app/views/records/edit_fields/_resource_type.html.erb
+++ b/app/views/records/edit_fields/_resource_type.html.erb
@@ -1,5 +1,7 @@
 <!-- overrides hyrax/app/views/records/edit_fields/_resource_type.html.erb -->
-
-<%= f.input :resource_type, as: :multi_value_select,
-            collection: ResourceTypesService.select_template_options(f.object.model_class),
+<% model_name = f.object.model_class %>
+<% set_default = ResourceTypesService.select_default(model_name) %>
+<%= f.input :resource_type, as: :select,
+            collection: ResourceTypesService.select_template_options(model_name),
+            selected: set_default,
             input_html: { class: 'form-control', multiple: true } %>

--- a/config/authorities/resource_types.yml
+++ b/config/authorities/resource_types.yml
@@ -13,8 +13,6 @@ terms:
     term: Dataset
   - id: Dissertation
     term: Dissertation
-  - id: Image
-    term: Image
   - id: Journal
     term: Journal
   - id: Map or Cartographic Material
@@ -29,8 +27,6 @@ terms:
     term: Presentation
   - id: Project
     term: Project
-  - id: Report
-    term: Report
   - id: Research Paper
     term: Research Paper
   - id: Software or Program Code
@@ -39,3 +35,89 @@ terms:
     term: Video
   - id: Other
     term: Other
+  - id: JournalArticle Journal article
+    term: Journal article
+  - id: JournalArticle Book review
+    term: Book review
+  - id: JournalArticle Data paper
+    term: Data paper
+  - id: JournalArticle Editorial
+    term: Editorial
+  - id: JournalArticle Letter to the editor
+    term: Letter to the editor
+  - id: JournalArticle Magazine article
+    term: Magazine article
+  - id: JournalArticle Newspaper article
+    term: Newspaper article
+  - id: Book Grey literature
+    term: Grey literature
+  - id: Book Technical documentation
+    term: Technical documentation
+  - id: Book Working paper
+    term: Working paper
+  - id: BookContribution Book chapter
+    term: Book chapter
+  - id: BookContribution Book editorial
+    term: Book editorial
+  - id: ConferenceItem Abstract
+    term: Abstract
+  - id: ConferenceItem Conference paper (published)
+    term: Conference paper (published)
+  - id: ConferenceItem Conference paper (unpublished)
+    term: Conference paper (unpublished)
+  - id: ConferenceItem Conference poster (published)
+    term: Conference poster (published)
+  - id: ConferenceItem Conference poster (unpublished)
+    term: Conference poster (unpublished)
+  - id: ConferenceItem Lecture
+    term: Lecture
+  - id: ConferenceItem Presentation
+    term: Presentation
+  - id: Report Policy report
+    term: Policy report
+  - id: Report Research report
+    term: Research report
+  - id: Report Technical report
+    term: Technical report
+  - id: Dataset Numerical dataset
+    term: Numerical dataset
+  - id: Dataset Geographical dataset
+    term: Geographical dataset
+  - id: Dataset Software
+    term: Software
+  - id: Dataset Database
+    term: Database
+  - id: GenericWork Blog post
+    term: Blog post
+  - id: GenericWork Cartographic material
+    term: Cartographic material
+  - id: GenericWork Exhibition
+    term: Exhibition
+  - id: GenericWork Interactive resource
+    term: Interactive resource
+  - id: GenericWork Learning object
+    term: Learning object
+  - id: GenericWork Patent
+    term: Patent
+  - id: GenericWork Software
+    term: Software
+  - id: GenericWork Sound
+    term: Sound
+  - id: GenericWork Technical documentation
+    term: Technical documentation
+  - id: GenericWork Thesis (doctoral)
+    term: Thesis (doctoral)
+  - id: GenericWork Musical notation
+    term: Musical notation
+  - id: GenericWork Website
+    term: Website
+  - id: GenericWork Workflow
+    term: Workflow
+  - id: GenericWork Other
+    term: Other
+  - id: Image Moving image
+    term: Moving image
+  - id: Image Still image
+    term: Still image
+  - id: Image 3D image
+    term: 3D image

--- a/config/authorities/resource_types.yml
+++ b/config/authorities/resource_types.yml
@@ -3,13 +3,13 @@ terms:
     term: Article
   - id: Audio
     term: Audio
-  - id: Book
+  - id: Book default Book
     term: Book
   - id: Capstone Project
     term: Capstone Project
   - id: Conference Proceeding
     term: Conference Proceeding
-  - id: Dataset
+  - id: Dataset default Dataset
     term: Dataset
   - id: Dissertation
     term: Dissertation
@@ -35,7 +35,7 @@ terms:
     term: Video
   - id: Other
     term: Other
-  - id: JournalArticle Journal article
+  - id: JournalArticle default Journal article
     term: Journal article
   - id: JournalArticle Book review
     term: Book review
@@ -55,7 +55,7 @@ terms:
     term: Technical documentation
   - id: Book Working paper
     term: Working paper
-  - id: BookContribution Book chapter
+  - id: BookContribution default Book chapter
     term: Book chapter
   - id: BookContribution Book editorial
     term: Book editorial
@@ -63,7 +63,7 @@ terms:
     term: Abstract
   - id: ConferenceItem Conference paper (published)
     term: Conference paper (published)
-  - id: ConferenceItem Conference paper (unpublished)
+  - id: ConferenceItem default Conference paper (unpublished)
     term: Conference paper (unpublished)
   - id: ConferenceItem Conference poster (published)
     term: Conference poster (published)
@@ -75,7 +75,7 @@ terms:
     term: Presentation
   - id: Report Policy report
     term: Policy report
-  - id: Report Research report
+  - id: Report default Research report
     term: Research report
   - id: Report Technical report
     term: Technical report
@@ -117,7 +117,7 @@ terms:
     term: Other
   - id: Image Moving image
     term: Moving image
-  - id: Image Still image
+  - id: Image default Still image
     term: Still image
   - id: Image 3D image
     term: 3D image

--- a/config/locales/journal_article.en.yml
+++ b/config/locales/journal_article.en.yml
@@ -31,6 +31,7 @@ en:
         official_link: Please enter the official URL, e.g. the publisher's link to the item.
         place_of_publication: Enter the town/city and country, or country only, e.g. London, UK or UK
         abstract: Please provide a short abstract or description of the item.
+        resource_type: If required, select the specific type of resource that best describes the work; otherwise the default resource type is displayed.
     labels:
       defaults:
         org_unit: Organisational Unit


### PR DESCRIPTION
Trello card [#2691](https://trello.com/c/4WRrc90b)

Changes to Resource Type field:
- is a required field
- drop-down menu displays custom options according to the model
- default option is pre-selected

WIP - left to do:
- modify the display on search result to include only the sub-term without the model class name (i.e. "Book chapter" only instead of "BookContribution Book chapter") - this is done (by `app/renderers/resource_type_renderer.rb`) for the individual record show page