### PR TITLE
Rename "contributor" and "editor" fields classes instead of "creator"…

### DIFF
--- a/app/views/generic_works/ubiquity/contributor/_edit_array_form.html.erb
+++ b/app/views/generic_works/ubiquity/contributor/_edit_array_form.html.erb
@@ -27,11 +27,11 @@
                      name: "generic_work[contributor_group][][contributor_isni]"
   %>
   <br>
-  <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
+  <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="generic_work_contributor_organization_name">
     contributor organization name</label>
 
   <%= text_field_tag  "generic_work[contributor_group][][contributor_organization_name]", nil,
-                      class: "ubiquity_creator_organization_name generic_work_creator_organization_name form-control multi-text-field multi_value",
+                      class: "ubiquity_contributor_organization_name generic_work_contributor_organization_name form-control multi-text-field multi_value",
                       placeholder: 'Add contributor organization name',
                       name: "generic_work[contributo_group][][contributor_organization_name]"
   %>

--- a/app/views/generic_works/ubiquity/contributor/_edit_array_hash_form.html.erb
+++ b/app/views/generic_works/ubiquity/contributor/_edit_array_hash_form.html.erb
@@ -20,11 +20,11 @@
     %>
    <br/>
    <br/>
-   <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
+   <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="generic_work_contributor_organization_name">
      contributor organization name</label>
 
    <%= text_field_tag  "generic_work[contributor_group][][contributor_organization_name]", hash.dig("contributor_organization_name"),
-                       class: "ubiquity_creator_organization_name generic_work_creator_organization_name form-control multi-text-field multi_value",
+                       class: "ubiquity_contributor_organization_name generic_work_contributor_organization_name form-control multi-text-field multi_value",
                        placeholder: 'Add contributor organization name',
                        name: "generic_work[contributor_group][][contributor_organization_name]"
    %>

--- a/app/views/generic_works/ubiquity/contributor/_edit_hash_form.html.erb
+++ b/app/views/generic_works/ubiquity/contributor/_edit_hash_form.html.erb
@@ -25,11 +25,11 @@
 
     <% end %>
    <br/>
-   <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
+   <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="generic_work_contributor_organization_name">
      contributor organization name</label>
 
    <%= text_field_tag  "generic_work[contributor_group][][contributor_organization_name]", hash.dig("contributor_organization_name"),
-                       class: "ubiquity_creator_organization_name generic_work_creator_organization_name form-control multi-text-field multi_value",
+                       class: "ubiquity_contributor_organization_name generic_work_contributor_organization_name form-control multi-text-field multi_value",
                        placeholder: 'Add contributor organization name',
                        name: "generic_work[contributor_group][][contributor_organization_name]"
    %>

--- a/app/views/generic_works/ubiquity/contributor/_new_form.html.erb
+++ b/app/views/generic_works/ubiquity/contributor/_new_form.html.erb
@@ -17,11 +17,11 @@
                      name: "generic_work[contributor_group][][contributor_isni]"
   %>
   <br/>
-  <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
+  <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="generic_work_contributor_organization_name">
   contributor organization name</label>
 
   <%= text_field_tag  "generic_work[contributor_group][][contributor_organization_name]", nil,
-                      class: "ubiquity_creator_organization_name generic_work_creator_organization_name form-control multi-text-field multi_value",
+                      class: "ubiquity_contributor_organization_name generic_work_contributor_organization_name form-control multi-text-field multi_value",
                       placeholder: 'Add contributor organization name',
                       name: "generic_work[contributor_group][][contributor_organization_name]"
   %>

--- a/app/views/generic_works/ubiquity/editor/_edit_array_hash_form.html.erb
+++ b/app/views/generic_works/ubiquity/editor/_edit_array_hash_form.html.erb
@@ -7,7 +7,7 @@
    <label class="control-label multi_value optional" for="generic_work_editor_name_type">
     editor name type</label>
 
-    <%= select_tag "generic_work[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("editor_name_type")), class:  'ubiquity_creator_name_type' %>
+    <%= select_tag "generic_work[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("editor_name_type")), class:  'ubiquity_editor_name_type' %>
 
   <br/>
   <label class="control-label multi_value optional" for="generic_work_editor_isni">
@@ -19,11 +19,11 @@
   %>
   <br>
   <br/>
-  <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
+  <label class="ubiquity_editor_organization_name control-label multi_value optional" for="generic_work_editor_organization_name">
     editor organization name</label>
 
   <%= text_field_tag  "generic_work[editor_group][][editor_organization_name]", hash.dig("editor_organization_name"),
-                      class: "ubiquity_creator_organization_name generic_work_editor_organization_name form-control multi-text-field multi_value",
+                      class: "ubiquity_editor_organization_name generic_work_editor_organization_name form-control multi-text-field multi_value",
                       placeholder: 'Add editor organization name',
                       name: "generic_work[editor_group][][editor_organization_name]"
   %>

--- a/app/views/generic_works/ubiquity/editor/_new_form.html.erb
+++ b/app/views/generic_works/ubiquity/editor/_new_form.html.erb
@@ -3,7 +3,7 @@
   <label class="control-label multi_value optional" for="generic_work_editor_name_type">
     editor name type</label>
 
-  <%= select_tag "generic_work[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s), class:  'ubiquity_creator_name_type' %>
+  <%= select_tag "generic_work[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s), class:  'ubiquity_editor_name_type' %>
 
   <br/>
   <label class="control-label multi_value optional" for="generic_work_editor_isni">
@@ -15,11 +15,11 @@
                      name: "generic_work[editor_group][][editor_isni]"
   %>
   <br/>
-  <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
+  <label class="ubiquity_editor_organization_name control-label multi_value optional" for="generic_work_editor_organization_name">
     editor organization name</label>
 
   <%= text_field_tag  "generic_work[editor_group][][editor_organization_name]", nil,
-                      class: " generic_work_creator_organization_name form-control multi-text-field multi_value",
+                      class: "ubiquity_editor_organization_name generic_work_editor_organization_name form-control multi-text-field multi_value",
                       placeholder: 'Add editor organization name',
                       name: "generic_work[editor_group][][editor_organization_name]"
   %>

--- a/app/views/journal_articles/ubiquity/contributor/_edit_array_hash_form.html.erb
+++ b/app/views/journal_articles/ubiquity/contributor/_edit_array_hash_form.html.erb
@@ -8,7 +8,7 @@
     contributor name type</label>
 
     <%= select_tag "journal_article[contributor_group][][contributor_name_type]",
-       content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("contributor_name_type")), class: "ubiquity_creator_name_type" %>
+       content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("contributor_name_type")), class: "ubiquity_contributor_name_type" %>
   <br/>
   <label class="control-label multi_value optional" for="journal_article_contributor_type">
    Contributor type</label>
@@ -26,11 +26,11 @@
                      name: "journal_article[contributor_group][][contributor_isni]"
   %>
   <br/>
-  <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
+  <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="journal_article_contributor_organization_name">
     contributor organization name</label>
 
   <%= text_field_tag  "journal_article[contributor_group][][contributor_organization_name]", hash.dig("contributor_organization_name"),
-                      class: "ubiquity_creator_organization_name generic_work_creator_organization_name form-control multi-text-field multi_value",
+                      class: "ubiquity_contributor_organization_name journal_article_contributor_organization_name form-control multi-text-field multi_value",
                       placeholder: 'Add contributor organization name',
                       name: "journal_article[contributor_group][][contributor_organization_name]"
   %>

--- a/app/views/journal_articles/ubiquity/contributor/_new_form.html.erb
+++ b/app/views/journal_articles/ubiquity/contributor/_new_form.html.erb
@@ -17,11 +17,11 @@
 
   <br/>
 
-    <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
+    <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="journal_article_contributor_organization_name">
       contributor organization name</label>
 
     <%= text_field_tag  "journal_article[contributor_group][][contributor_organization_name]", nil,
-                        class: "ubiquity_creator_organization_name generic_work_creator_organization_name form-control multi-text-field multi_value",
+                        class: "ubiquity_contributor_organization_name journal_article_contributor_organization_name form-control multi-text-field multi_value",
                         placeholder: 'Add contributor organization name',
                         name: "journal_article[contributor_group][][contributor_organization_name]"
     %>

--- a/app/views/shared/ubiquity/_editor_js.html.erb
+++ b/app/views/shared/ubiquity/_editor_js.html.erb
@@ -62,12 +62,12 @@
    $(document).on("turbolinks:load", function(){
      return $("body").on("change",".ubiquity_editor_name_type", function(event){
        if (event.target.value == 'Personal') {
-         $(this).siblings(".ubiquity_creator_organization_name").hide();
+         $(this).siblings(".ubiquity_editor_organization_name").hide();
          $(this).siblings(".ubiquity_personal_fields").show();
        } else {
 
         $(this).siblings(".ubiquity_personal_fields").hide();
-        $(this).siblings(".ubiquity_creator_organization_name").show();
+        $(this).siblings(".ubiquity_editor_organization_name").show();
        }
       });
    });
@@ -77,11 +77,11 @@
       $(".ubiquity_editor_name_type").each(function() {
         _this = this;
          if (this.value == 'Personal') {
-           $(this).siblings(".ubiquity_creator_organization_name").hide();
+           $(this).siblings(".ubiquity_editor_organization_name").hide();
            $(this).siblings(".ubiquity_personal_fields").show();
          } else if(this.value == "Organisational"){
           $(this).siblings(".ubiquity_personal_fields").hide();
-          $(this).siblings(".ubiquity_creator_organization_name").show();
+          $(this).siblings(".ubiquity_editor_organization_name").show();
         } else {
           $('.ubiquity_editor_name_type:last').val('Personal').change()
         }

--- a/app/views/shared/ubiquity/contributor/_contributor_js.html.erb
+++ b/app/views/shared/ubiquity/contributor/_contributor_js.html.erb
@@ -23,7 +23,7 @@
              //increment hidden_field counter after cloning
              hiddenFieldIncrementer(lastInputCount, cloneUbiDiv);
             $(`${ubiquityContributorClass}` +  ':last').after(cloneUbiDiv)
-            $('.ubiquity_creator_name_type:last').val('Personal').change()
+            $('.ubiquity_contributor_name_type:last').val('Personal').change()
 
         });
     });
@@ -60,12 +60,12 @@
     $(document).on("turbolinks:load", function(){
       return $("body").on("change",".ubiquity_contributor_name_type", function(event){
         if (event.target.value == 'Personal') {
-          $(this).siblings(".ubiquity_creator_organization_name").hide();
+          $(this).siblings(".ubiquity_contributor_organization_name").hide();
           $(this).siblings(".ubiquity_personal_fields").show();
         } else {
 
          $(this).siblings(".ubiquity_personal_fields").hide();
-         $(this).siblings(".ubiquity_creator_organization_name").show();
+         $(this).siblings(".ubiquity_contributor_organization_name").show();
         }
        });
     });
@@ -76,11 +76,11 @@
          _this = this;
           if (this.value == 'Personal') {
 
-            $(this).siblings(".ubiquity_creator_organization_name").hide();
+            $(this).siblings(".ubiquity_contributor_organization_name").hide();
             $(this).siblings(".ubiquity_personal_fields").show();
           } else if(this.value == "Organisational") {
            $(this).siblings(".ubiquity_personal_fields").hide();
-           $(this).siblings(".ubiquity_creator_organization_name").show();
+           $(this).siblings(".ubiquity_contributor_organization_name").show();
          } else {
            $('.ubiquity_contributor_name_type:last').val('Personal').change()
          }


### PR DESCRIPTION
… on Generic Work and Journal Article partials.
As discussed, `ubiquity_creator_organization_name` class becomes `ubiquity_contributor_organization_name` or `ubiquity_editor_organization_name` depending on the field being rendered.