### PR TITLE
Metadata: Related identifier multi-part field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -119,7 +119,8 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("project_name", :stored_searchable), label: "Project Name"
     config.add_index_field solr_name("official_link", :stored_searchable), label: "Official link"
     config.add_index_field solr_name("rights_holder", :stored_searchable), label: "Rights holder"
-    config.add_index_field solr_name("alternate_identifier"), helper_method: :display_alt_id_fields_in_search, label: "Alternate Identifier"
+    config.add_index_field solr_name("alternate_identifier"), helper_method: :display_multi_part_fields_in_search, label: "Alternate Identifier"
+    config.add_index_field solr_name("related_identifier"), helper_method: :display_multi_part_fields_in_search, label: "Related Identifier"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/app/forms/ubiquity/all_forms_shared_behaviour.rb
+++ b/app/forms/ubiquity/all_forms_shared_behaviour.rb
@@ -11,8 +11,8 @@ module Ubiquity
                     :creator_family_name, :creator_orcid, :creator_isni,
                     :creator_position
 
-      attr_accessor :alternate_identifier_group
-      self.terms += %i[alternate_identifier]
+      attr_accessor :alternate_identifier_group, :related_identifier_group
+      self.terms += %i[alternate_identifier related_identifier]
 
     end
 
@@ -44,6 +44,8 @@ module Ubiquity
           ]}
 
           permitted_params << { alternate_identifier_group: %i[alternate_identifier alternate_identifier_type] }
+
+          permitted_params << { related_identifier_group: %i[related_identifier related_identifier_type relation_type] }
 
         end
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,17 +3,8 @@ module ApplicationHelper
   include GroupNavigationHelper
   include MultipleMetadataFieldsHelper
   include Ubiquity::SolrSearchDisplayHelpers
-  
+
   def check_has_editor_fields?(presenter)
     ["Book", "BookContribution", "ConferenceItem", "Report", "GenericWork"].include? presenter
   end
-
-  ## method below was worked out reading http://jessiekeck.com/customizing-blacklight/metadata_fields/
-  def display_alt_id_fields_in_search(options={})
-    field = JSON.parse(options[:value][0]).map do |alt_id|
-      alt_id["alternate_identifier"] << ", " << alt_id["alternate_identifier_type"]
-    end
-    field.join
-  end
-
 end

--- a/app/helpers/ubiquity/solr_search_display_helpers.rb
+++ b/app/helpers/ubiquity/solr_search_display_helpers.rb
@@ -1,25 +1,36 @@
 module Ubiquity
   module SolrSearchDisplayHelpers
-      #When this is called from CatalogController via config.add_index_field solr_name("creator"), helper_method: :display_creator_fields_in_search, label: "Creator"
-      #it gives you access to an instance of solr document which is what options represent
-      #Therefor options[:value][0] represents the json value stored in the creator metadata field but in solr called creator_tesim
-      def display_creator_fields_in_search(options={})
-        data ||= pass_model(options)
-        #source: 'search' is temporal and for now it stops multiple labels for linked  metadata on the search page
-        render "shared/ubiquity/creator/show", presenter: data, source: 'search'
-      end
+    # When this is called from CatalogController via config.add_index_field solr_name("creator"), helper_method: :display_creator_fields_in_search, label: "Creator"
+    # it gives you access to an instance of solr document which is what options represent
+    # Therefor options[:value][0] represents the json value stored in the creator metadata field but in solr called creator_tesim
+    def display_creator_fields_in_search(options={})
+      data ||= pass_model(options)
+      #source: 'search' is temporal and for now it stops multiple labels for linked  metadata on the search page
+      render "shared/ubiquity/creator/show", presenter: data, source: 'search'
+    end
 
-      def display_contributor_fields_in_search(options={})
-        data ||= pass_model(options)
-        render "shared/ubiquity/contributor/show", presenter: data, source: 'search'
-      end
+    def display_contributor_fields_in_search(options={})
+      data ||= pass_model(options)
+      render "shared/ubiquity/contributor/show", presenter: data, source: 'search'
+    end
 
-      def display_editor_fields_in_search(options={})
-        data ||= pass_model(options)
-        render "shared/ubiquity/editor/show", presenter: data, source: 'search'
-      end
+    def display_editor_fields_in_search(options={})
+      data ||= pass_model(options)
+      render "shared/ubiquity/editor/show", presenter: data, source: 'search'
+    end
 
-      private
+    # method below was worked out reading http://jessiekeck.com/customizing-blacklight/metadata_fields/
+    def display_multi_part_fields_in_search(options={})
+      field = JSON.parse(options[:value][0]).map do |hash|
+        content = []
+        hash.each_value { |v| content << v }
+        content
+      end
+      field.join(', ')
+    end
+
+    private
+
       def pass_model(options)
         my_model = options[:document].hydra_model.to_s
         my_id = options[:document].id

--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -7,6 +7,7 @@ module Ubiquity
       before_save :save_contributor
       before_save :save_creator
       before_save :save_alternate_identifier
+      before_save :save_related_identifier
 
       attr_accessor :contributor_group, :contributor_name_type, :contributor_type, :contributor_given_name,
                     :contributor_family_name, :contributor_orcid, :contributor_isni,
@@ -16,7 +17,7 @@ module Ubiquity
                     :creator_family_name, :creator_orcid, :creator_isni,
                     :creator_position
 
-      attr_accessor :alternate_identifier_group
+      attr_accessor :alternate_identifier_group, :related_identifier_group
 
     end
 
@@ -50,6 +51,14 @@ module Ubiquity
         new_alternate_identifier_group = remove_hash_keys_with_empty_and_nil_values(self.alternate_identifier_group)
         alternate_identifier_json = new_alternate_identifier_group.to_json
         self.alternate_identifier = [alternate_identifier_json]
+      end
+    end
+
+    def save_related_identifier
+      if self.related_identifier_group.present?
+        new_related_identifier_group = remove_hash_keys_with_empty_and_nil_values(self.related_identifier_group)
+        related_identifier_json = new_related_identifier_group.to_json
+        self.related_identifier = [related_identifier_json]
       end
     end
   end

--- a/app/models/concerns/ubiquity/basic_metadata_decorator.rb
+++ b/app/models/concerns/ubiquity/basic_metadata_decorator.rb
@@ -50,6 +50,9 @@ module Ubiquity
       property :alternate_identifier, predicate: ::RDF::Vocab::BF2.term(:Local) do |index|
         index.as :stored_searchable
       end
+      property :related_identifier, predicate: ::RDF::Vocab::BF2.identifiedBy do |index|
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -56,5 +56,5 @@ class SolrDocument
   attribute :event_date, Solr::Array, solr_name('event_date')
   attribute :book_title, Solr::Array, solr_name('book_title')
   attribute :alternate_identifier, Solr::Array, solr_name('alternate_identifier')
-
+  attribute :related_identifier, Solr::Array, solr_name('related_identifier')
 end

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -6,7 +6,7 @@ module Hyku
              :funder, :fndr_project_ref, :add_info, :date_published, :date_accepted, :date_submitted,
              :journal_title, :issue, :volume, :pagination, :article_num, :project_name, :rights_holder,
              :official_link, :place_of_publication, :series_name, :edition, :abstract,
-             :event_title, :event_date, :book_title,  :editor, :alternate_identifier,
+             :event_title, :event_date, :book_title,  :editor, :alternate_identifier, :related_identifier,
              to: :solr_document
 
     def manifest_url

--- a/app/services/related_identifier_type_service.rb
+++ b/app/services/related_identifier_type_service.rb
@@ -1,0 +1,5 @@
+class RelatedIdentifierTypeService < Hyrax::QaSelectService
+  def initialize(_authority_name = nil)
+    super('related_identifier_type')
+  end
+end

--- a/app/services/relation_type_service.rb
+++ b/app/services/relation_type_service.rb
@@ -1,0 +1,5 @@
+class RelationTypeService < Hyrax::QaSelectService
+  def initialize(_authority_name = nil)
+    super('relation_type')
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -52,3 +52,4 @@
 
 <!-- Future refactoring: can we achieve this below with an AlternateIdentifierAttributeRenderer in app/renderers -->
 <%= render "shared/ubiquity/alternate_identifier/show", presenter: @presenter %>
+<%= render "shared/ubiquity/related_identifier/show", presenter: @presenter %>

--- a/app/views/records/edit_fields/_related_identifier.html.erb
+++ b/app/views/records/edit_fields/_related_identifier.html.erb
@@ -1,0 +1,6 @@
+<% if curation_concern.new_record? %>
+  <%= render "shared/ubiquity/related_identifier/new_form" %>
+<% else %>
+  <%= render "shared/ubiquity/related_identifier/edit_form", curation_concern: curation_concern %>
+<% end %>
+<%= render "shared/ubiquity/related_identifier/related_identifier_js" %>

--- a/app/views/shared/ubiquity/alternate_identifier/_alternate_identifier_js.html.erb
+++ b/app/views/shared/ubiquity/alternate_identifier/_alternate_identifier_js.html.erb
@@ -8,6 +8,8 @@
             var ubiquityAlternateIdentifierClass = $(this).attr('data-addUbiquityAlternateIdentifier');
             var cloneUbiDiv = $(this).parent('div' + `${ubiquityAlternateIdentifierClass}`).clone();
             _this = this;
+            cloneUbiDiv.find('input').val('');
+            cloneUbiDiv.find('option').attr('selected', false);
             $(`${ubiquityAlternateIdentifierClass}`+ ':last').after(cloneUbiDiv)
         });
     });

--- a/app/views/shared/ubiquity/related_identifier/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_edit_array_hash_form.html.erb
@@ -1,0 +1,38 @@
+<% template = @curation_concern.class.to_s.underscore %>
+
+<% array_of_hash.each_with_index do |hash, index| %>
+
+  <div class="ubiquity-meta-related-identifier" >
+    <label class="control-label multi_value optional" for="<% template %>_related_identifier">Related identifier</label>
+    <p class="help-block">Globally unique identifiers, such as ISNI, ARK, ISBN, ISSN, EISSN, arXiv, etc.</p>
+    <%= text_field_tag "#{template}[related_identifier_group][][related_identifier]", hash.dig("related_identifier"),
+                       class: "#{template}_related_identifier_group form-control multi-text-field multi_value",
+                       name: "#{template}[related_identifier_group][][related_identifier]"
+    %>
+    <br>
+    <label class="control-label multi_value optional" for="<% template %>_related_identifier_type">
+      Type of related identifier</label>
+    <p class="help-block">If you have listed a related identifier, then please select what type.</p>
+    <%= select_tag "#{template}[related_identifier_group][][related_identifier_type]",
+        content_tag(:option, 'select one...', :value => "") + options_from_collection_for_select(RelatedIdentifierTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("related_identifier_type")),
+        {:class => 'form-control multi-text-field multi_value'} %>
+
+    <br>
+    <label class="control-label multi_value optional" for="<% template %>_relation_type">
+      Relationship of related identifier</label>
+    <p class="help-block">If you have listed a related identifier, then state its relationship to the work, e.g. cites
+      or continues the work.</p>
+    <%= select_tag "#{template}[related_identifier_group][][relation_type]",
+        content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select(RelationTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("relation_type")),
+        {:class => 'form-control multi-text-field multi_value'} %>
+
+    <br>
+    <a href="#" style="color:red;"  class="remove_related_identifier form-group" data-removeUbiquityrelatedIdentifier=".ubiquity-meta-related-identifier">
+      <span class="glyphicon glyphicon-remove"></span>
+      <span class="controls-remove-text">Remove</span>
+    </a>
+    |
+    <a href="#" class="add_related_identifier" data-addUbiquityrelatedIdentifier=".ubiquity-meta-related-identifier">Add another </a>
+    <br><br>
+  </div>
+<% end %>

--- a/app/views/shared/ubiquity/related_identifier/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_edit_array_hash_form.html.erb
@@ -6,7 +6,7 @@
     <label class="control-label multi_value optional" for="<% template %>_related_identifier">Related identifier</label>
     <p class="help-block">Globally unique identifiers, such as ISNI, ARK, ISBN, ISSN, EISSN, arXiv, etc.</p>
     <%= text_field_tag "#{template}[related_identifier_group][][related_identifier]", hash.dig("related_identifier"),
-                       class: "#{template}_related_identifier_group form-control multi-text-field multi_value",
+                       class: "#{template}_related_identifier_group form-control multi-text-field multi_value related_identifier",
                        name: "#{template}[related_identifier_group][][related_identifier]"
     %>
     <br>
@@ -15,7 +15,7 @@
     <p class="help-block">If you have listed a related identifier, then please select what type.</p>
     <%= select_tag "#{template}[related_identifier_group][][related_identifier_type]",
         content_tag(:option, 'select one...', :value => "") + options_from_collection_for_select(RelatedIdentifierTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("related_identifier_type")),
-        {:class => 'form-control multi-text-field multi_value'} %>
+        {:class => 'form-control multi-text-field multi_value related_identifier_type'} %>
 
     <br>
     <label class="control-label multi_value optional" for="<% template %>_relation_type">
@@ -24,7 +24,7 @@
       or continues the work.</p>
     <%= select_tag "#{template}[related_identifier_group][][relation_type]",
         content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select(RelationTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("relation_type")),
-        {:class => 'form-control multi-text-field multi_value'} %>
+        {:class => 'form-control multi-text-field multi_value related_identifier_relation'} %>
 
     <br>
     <a href="#" style="color:red;"  class="remove_related_identifier form-group" data-removeUbiquityrelatedIdentifier=".ubiquity-meta-related-identifier">

--- a/app/views/shared/ubiquity/related_identifier/_edit_form.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_edit_form.html.erb
@@ -1,0 +1,5 @@
+<% array_of_hash = get_model(curation_concern.class, curation_concern.id, 'related_identifier') %>
+
+<% if (array_of_hash.class == Array && array_of_hash.first.class == Hash)  %>
+  <%= render "shared/ubiquity/related_identifier/edit_array_hash_form", array_of_hash: array_of_hash %>
+<% end %>

--- a/app/views/shared/ubiquity/related_identifier/_new_form.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_new_form.html.erb
@@ -4,7 +4,7 @@
   <label class="control-label multi_value optional" for="<% template %>_related_identifier">Related identifier</label>
   <p class="help-block">Globally unique identifiers, such as ISNI, ARK, ISBN, ISSN, EISSN, arXiv, etc.</p>
   <%= text_field_tag "#{template}[related_identifier_group][][related_identifier]", nil,
-                     class: "#{template}_related_identifier_group form-control multi-text-field multi_value",
+                     class: "#{template}_related_identifier_group form-control multi-text-field multi_value related_identifier",
                      name: "#{template}[related_identifier_group][][related_identifier]"
   %>
   <br>
@@ -13,7 +13,7 @@
   <p class="help-block">If you have listed a related identifier, then please select what type.</p>
   <%= select_tag "#{template}[related_identifier_group][][related_identifier_type]",
       content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select(RelatedIdentifierTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
-      {:class => 'form-control multi-text-field multi_value'} %>
+      {:class => 'form-control multi-text-field multi_value related_identifier_type'} %>
 
   <br>
   <label class="control-label multi_value optional" for="<% template %>_relation_type">
@@ -22,7 +22,7 @@
     continues the work.</p>
   <%= select_tag "#{template}[related_identifier_group][][relation_type]",
       content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select(RelationTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
-      {:class => 'form-control multi-text-field multi_value'} %>
+      {:class => 'form-control multi-text-field multi_value related_identifier_relation'} %>
 
   <br>
   <a href="#" style="color:red;" class="remove_related_identifier form-group" data-removeUbiquityrelatedIdentifier=".ubiquity-meta-related-identifier">

--- a/app/views/shared/ubiquity/related_identifier/_new_form.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_new_form.html.erb
@@ -1,0 +1,36 @@
+<% template = @curation_concern.class.to_s.underscore %>
+
+<div class="ubiquity-meta-related-identifier" >
+  <label class="control-label multi_value optional" for="<% template %>_related_identifier">Related identifier</label>
+  <p class="help-block">Globally unique identifiers, such as ISNI, ARK, ISBN, ISSN, EISSN, arXiv, etc.</p>
+  <%= text_field_tag "#{template}[related_identifier_group][][related_identifier]", nil,
+                     class: "#{template}_related_identifier_group form-control multi-text-field multi_value",
+                     name: "#{template}[related_identifier_group][][related_identifier]"
+  %>
+  <br>
+  <label class="control-label multi_value optional" for="<% template %>_related_identifier_type">
+    Type of related identifier</label>
+  <p class="help-block">If you have listed a related identifier, then please select what type.</p>
+  <%= select_tag "#{template}[related_identifier_group][][related_identifier_type]",
+      content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select(RelatedIdentifierTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
+      {:class => 'form-control multi-text-field multi_value'} %>
+
+  <br>
+  <label class="control-label multi_value optional" for="<% template %>_relation_type">
+    Relationship of related identifier</label>
+  <p class="help-block">If you have listed a related identifier, then state its relationship to the work, e.g. cites or
+    continues the work.</p>
+  <%= select_tag "#{template}[related_identifier_group][][relation_type]",
+      content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select(RelationTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
+      {:class => 'form-control multi-text-field multi_value'} %>
+
+  <br>
+  <a href="#" style="color:red;" class="remove_related_identifier form-group" data-removeUbiquityrelatedIdentifier=".ubiquity-meta-related-identifier">
+    <span class="glyphicon glyphicon-remove"></span>
+    <span class="controls-remove-text">Remove</span>
+  </a>
+  |
+  <a href="#" class="add_related_identifier" data-addUbiquityrelatedIdentifier=".ubiquity-meta-related-identifier">Add
+    another </a>
+  <br><br>
+</div>

--- a/app/views/shared/ubiquity/related_identifier/_related_identifier_js.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_related_identifier_js.html.erb
@@ -31,4 +31,25 @@
         }
     }
 
+    // make related_identifiers type and relation fields compulsory if the first field is filled in
+    $(document).on("turbolinks:load", function(){
+        return $("body").on("blur", ".related_identifier", function (event) {
+            event.preventDefault();
+            //trim Remove the whitespace from the beginning and end of a string
+            var input1Value = $.trim($(this).val());
+            console.log('value', input1Value);
+            var input2 = $(".related_identifier_type");
+            var input3 = $(".related_identifier_relation");
+            if (input1Value) {
+                console.log('enter')
+                input2.prop('required', true);
+                input3.prop('required', true);
+            } else {
+                input2.removeAttr('required');
+                input3.removeAttr('required');
+            }
+
+        });
+    });
+
 </script>

--- a/app/views/shared/ubiquity/related_identifier/_related_identifier_js.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_related_identifier_js.html.erb
@@ -8,6 +8,8 @@
             var ubiquityRelatedIdentifierClass = $(this).attr('data-addUbiquityRelatedIdentifier');
             var cloneUbiDiv = $(this).parent('div' + `${ubiquityRelatedIdentifierClass}`).clone();
             _this = this;
+            cloneUbiDiv.find('input').val('');
+            cloneUbiDiv.find('option').attr('selected', false);
             $(`${ubiquityRelatedIdentifierClass}`+ ':last').after(cloneUbiDiv)
         });
     });
@@ -37,11 +39,11 @@
             event.preventDefault();
             //trim Remove the whitespace from the beginning and end of a string
             var input1Value = $.trim($(this).val());
-            console.log('value', input1Value);
+            // console.log('value', input1Value);
             var input2 = $(".related_identifier_type");
             var input3 = $(".related_identifier_relation");
             if (input1Value) {
-                console.log('enter')
+                // console.log('enter')
                 input2.prop('required', true);
                 input3.prop('required', true);
             } else {

--- a/app/views/shared/ubiquity/related_identifier/_related_identifier_js.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_related_identifier_js.html.erb
@@ -1,0 +1,34 @@
+<script type="text/javascript">
+
+    // add linked fields
+    $(document).on("turbolinks:load", function(){
+
+        return $("body").on("click", ".add_related_identifier", function(event){
+            event.preventDefault();
+            var ubiquityRelatedIdentifierClass = $(this).attr('data-addUbiquityRelatedIdentifier');
+            var cloneUbiDiv = $(this).parent('div' + `${ubiquityRelatedIdentifierClass}`).clone();
+            _this = this;
+            $(`${ubiquityRelatedIdentifierClass}`+ ':last').after(cloneUbiDiv)
+        });
+    });
+
+    //remove linked fields
+    $(document).on("turbolinks:load", function(){
+        //$(document).ready(function() {
+        return $("body").on("click", ".remove_related_identifier", function(event){
+            event.preventDefault();
+            var ubiquityRelatedIdentifierClass = $(this).attr('data-removeUbiquityRelatedIdentifier');
+
+            _this = this;
+            removeUbiquityRelatedIdentifier(_this, ubiquityRelatedIdentifierClass);
+
+        });
+    });
+
+    function removeUbiquityRelatedIdentifier(self, related_identifierDiv) {
+        if ($(".ubiquity-meta-related-identifier").length > 1 ) {
+            $(self).parent('div' + `${related_identifierDiv}`).remove();
+        }
+    }
+
+</script>

--- a/app/views/shared/ubiquity/related_identifier/_show.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_show.html.erb
@@ -1,0 +1,5 @@
+<% array_of_hash = get_model(presenter.model, presenter.id, 'related_identifier') %>
+
+<% if (array_of_hash.class == Array && array_of_hash.first.class == Hash )  %>
+  <%= render "shared/ubiquity/related_identifier/show_array_hash", array_of_hash: array_of_hash  %>
+<% end %>

--- a/app/views/shared/ubiquity/related_identifier/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_show_array_hash.html.erb
@@ -1,0 +1,24 @@
+<tr>
+  <th>Related identifier</th>
+  <td>
+    <% array_of_hash.each do |hash| %>
+      <ul class="tabular">
+        <li class="attribute related_identifier">
+          <% if hash['related_identifier'] %>
+            <%= "identifier: #{hash['related_identifier']}" %>,&nbsp;
+          <% end %>
+        </li>
+        <li class="attribute related_identifier_type">
+          <% if hash['related_identifier_type'] %>
+            <%= "type: #{hash['related_identifier_type']}" %>
+          <% end %>
+        </li>
+        <li class="attribute relation_type">
+          <% if hash['related_identifier_type'] %>
+            <%= "relation: #{hash['relation_type']}" %>
+          <% end %>
+        </li>
+      </ul>
+    <% end %>
+  </td>
+</tr>

--- a/config/authorities/related_identifier_type.yml
+++ b/config/authorities/related_identifier_type.yml
@@ -1,0 +1,37 @@
+terms:
+  - id: ARK
+    term: ARK
+  - id: arXiv
+    term: arXiv
+  - id: bibcode
+    term: bibcode
+  - id: DOI
+    term: DOI
+  - id: EAN13
+    term: EAN13
+  - id: EISSN
+    term: EISSN
+  - id: Handle
+    term: Handle
+  - id: IGSN
+    term: IGSN
+  - id: ISBN
+    term: ISBN
+  - id: ISSN
+    term: ISSN
+  - id: ISTC
+    term: ISTC
+  - id: LISSN
+    term: LISSN
+  - id: LSID
+    term: LSID
+  - id: PMID
+    term: PMID
+  - id: PURL
+    term: PURL
+  - id: UPC
+    term: UPC
+  - id: URL
+    term: URL
+  - id: URN
+    term: URN

--- a/config/authorities/relation_type.yml
+++ b/config/authorities/relation_type.yml
@@ -1,0 +1,63 @@
+terms:
+  - id: IsCitedBy
+    term: IsCitedBy
+  - id: Cites
+    term: Cites
+  - id: IsSupplementTo
+    term: IsSupplementTo
+  - id: IsSupplementedBy
+    term: IsSupplementedBy
+  - id: IsContinuedBy
+    term: IsContinuedBy
+  - id: Continues
+    term: Continues
+  - id: IsDescribedBy
+    term: IsDescribedBy
+  - id: Describes
+    term: Describes
+  - id: HasMetadata
+    term: HasMetadata
+  - id: IsMetadataFor
+    term: IsMetadataFor
+  - id: HasVersion
+    term: HasVersion
+  - id: IsVersionOf
+    term: IsVersionOf
+  - id: IsNewVersionOf
+    term: IsNewVersionOf
+  - id: IsPreviousVersionOf
+    term: IsPreviousVersionOf
+  - id: IsPartOf
+    term: IsPartOf
+  - id: HasPart
+    term: HasPart
+  - id: IsReferencedBy
+    term: IsReferencedBy
+  - id: References
+    term: References
+  - id: IsDocumentedBy
+    term: IsDocumentedBy
+  - id: Documents
+    term: Documents
+  - id: IsCompiledBy
+    term: IsCompiledBy
+  - id: Compiles
+    term: Compiles
+  - id: IsVariantFormOf
+    term: IsVariantFormOf
+  - id: IsOriginalFormOf
+    term: IsOriginalFormOf
+  - id: IsIdenticalTo
+    term: IsIdenticalTo
+  - id: IsReviewedBy
+    term: IsReviewedBy
+  - id: Reviews
+    term: Reviews
+  - id: IsDerivedFrom
+    term: IsDerivedFrom
+  - id: IsSourceOf
+    term: IsSourceOf
+  - id: IsRequiredBy
+    term: IsRequiredBy
+  - id: Requires
+    term: Requires


### PR DESCRIPTION
Adds a multi-part field for Related identifier + Type of related identifier + Relationship of related identifier.


Follow up work on:
- Trello [#2636](https://trello.com/c/M4N5FcIq), and [#2662](https://trello.com/c/ITjb2hGv) through [#2666](https://trello.com/c/R8L08tdz)
- PR #20 