### PR TITLE
Fix label display

### DIFF
--- a/config/locales/book.en.yml
+++ b/config/locales/book.en.yml
@@ -12,7 +12,6 @@ en:
         series_name: Please enter the series title, e.g. British Library Research Publications
         edition: If this is not the first edition, please specifiy in the format e.g. 1st, 2nd. Leave blank if not required.
         isbn: ISBN, International Standard Book Number, if available
-        
     labels:
       defaults:
         isbn: ISBN

--- a/config/locales/journal_article.en.yml
+++ b/config/locales/journal_article.en.yml
@@ -43,3 +43,4 @@ en:
         doi: DOI
         issn: ISSN
         eissn: eISSN
+        isbn: ISBN


### PR DESCRIPTION
"ISBN" in capital letters on the template form. The default label was not being picked up from `config/locales/book.en.yml`, it is now in `config/locales/journal_article.en.yml`.