### PR TITLE
Submission forms - reorder metadata fields

### DIFF
--- a/app/forms/hyrax/article_form.rb
+++ b/app/forms/hyrax/article_form.rb
@@ -4,13 +4,11 @@ module Hyrax
     include ::Ubiquity::AllFormsSharedBehaviour
     self.model_class = ::Article
 
-    # alternate_identifier alternate_identifier_type
-    self.terms += %i[resource_type rendering_ids journal_title doi volume issue pagination
-                     place_of_publication issn eissn article_num date_published date_accepted date_submitted abstract
-                     institution org_unit refereed official_link project_name funder fndr_project_ref add_info
-                     rights_holder]
-    self.terms -= %i[based_near description source subject]
-    self.required_fields += %i[resource_type journal_title institution publisher date_published]
-    self.required_fields -= %i[keyword rights_statement]
+    self.terms += %i[title resource_type creator contributor rendering_ids doi journal_title
+                     alternate_identifier related_identifier volume issue pagination publisher
+                     place_of_publication issn eissn article_num date_published date_accepted date_submitted
+                     abstract keyword institution org_unit refereed official_link related_url project_name
+                     funder fndr_project_ref add_info language license rights_statement rights_holder]
+    self.required_fields += %i[journal_title]
   end
 end

--- a/app/forms/hyrax/book_contribution_form.rb
+++ b/app/forms/hyrax/book_contribution_form.rb
@@ -7,11 +7,10 @@ module Hyrax
     include Ubiquity::EditorMetadataFormBehaviour
 
     self.model_class = ::BookContribution
-    self.terms += %i[resource_type rendering_ids doi book_title series_name volume edition place_of_publication pagination isbn
-                     issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
-                     official_link project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= %i[based_near description source subject]
-    self.required_fields += %i[resource_type institution publisher date_published]
-    self.required_fields -= %i[keyword rights_statement]
+    self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier
+                     related_identifier book_title series_name volume edition editor publisher
+                     place_of_publication pagination isbn issn eissn date_published date_accepted date_submitted
+                     abstract keyword institution org_unit refereed official_link related_url project_name
+                     funder fndr_project_ref add_info language license rights_statement rights_holder]
   end
 end

--- a/app/forms/hyrax/book_form.rb
+++ b/app/forms/hyrax/book_form.rb
@@ -7,11 +7,11 @@ module Hyrax
     include Ubiquity::EditorMetadataFormBehaviour
 
     self.model_class = ::Book
-    self.terms += %i[resource_type rendering_ids doi series_name volume edition place_of_publication pagination isbn
-                     issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
-                     official_link project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= %i[based_near description source subject]
-    self.required_fields += %i[resource_type institution publisher date_published]
-    self.required_fields -= %i[keyword rights_statement]
+    self.terms += %i[title resource_type creator contributor rendering_ids doi
+                     alternate_identifier related_identifier series_name volume edition editor
+                     publisher place_of_publication pagination isbn issn eissn date_published
+                     date_accepted date_submitted abstract keyword institution org_unit refereed
+                     official_link related_url project_name funder fndr_project_ref add_info language
+                     license rights_statement rights_holder]
   end
 end

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -5,11 +5,11 @@ module Hyrax
     include Ubiquity::EditorMetadataFormBehaviour
 
     self.model_class = ::ConferenceItem
-    self.terms += %i[resource_type rendering_ids doi event_title event_date book_title series_name volume pagination
-                     place_of_publication issn eissn date_published date_accepted date_submitted abstract institution
-                     org_unit refereed official_link project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= %i[based_near description source subject]
-    self.required_fields += %i[resource_type institution publisher date_published]
-    self.required_fields -= %i[keyword rights_statement]
+    self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier
+                     related_identifier event_title event_date book_title series_name volume editor
+                     publisher place_of_publication pagination isbn issn eissn date_published
+                     date_accepted date_submitted abstract keyword institution org_unit refereed
+                     official_link related_url project_name funder fndr_project_ref
+                     add_info language license rights_statement rights_holder]
   end
 end

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -4,13 +4,12 @@ module Hyrax
   class DatasetForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     include ::Ubiquity::AllFormsSharedBehaviour
-    
+
     self.model_class = ::Dataset
-    self.terms += %i[resource_type rendering_ids doi version date_published place_of_publication
-                     date_accepted date_submitted abstract institution org_unit refereed official_link
-                     project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= %i[based_near description source subject]
-    self.required_fields += %i[resource_type institution publisher date_published]
-    self.required_fields -= %i[keyword rights_statement]
+    self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier
+                     version related_identifier publisher date_published place_of_publication
+                     date_published date_accepted date_submitted abstract keyword institution org_unit
+                     refereed official_link related_url project_name funder fndr_project_ref add_info
+                     language license rights_statement rights_holder]
   end
 end

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -8,12 +8,11 @@ module Hyrax
 
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
-    self.terms += %i[resource_type rendering_ids doi version series_name edition journal_title volume issue pagination
-                     place_of_publication isbn issn eissn article_num media date_published date_accepted date_submitted
-                     abstract institution org_unit official_link related_exhibition related_exhibition_date
-                     project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= %i[based_near description source subject]
-    self.required_fields += %i[resource_type institution publisher date_published]
-    self.required_fields -= %i[keyword rights_statement]
+    self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier
+                     version related_identifier series_name volume edition journal_title issue pagination
+                     editor publisher place_of_publication isbn issn eissn article_num media
+                     date_published date_accepted date_submitted abstract keyword institution org_unit
+                     refereed official_link related_url related_exhibition related_exhibition_date project_name
+                     funder fndr_project_ref add_info language license rights_statement rights_holder]
   end
 end

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -6,11 +6,10 @@ module Hyrax
     include ::Ubiquity::AllFormsSharedBehaviour
 
     self.model_class = ::Image
-    self.terms += %i[resource_type rendering_ids doi place_of_publication date_published date_accepted
-                     date_submitted abstract media institution org_unit official_link related_exhibition
-                     related_exhibition_date project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= %i[based_near description source subject]
-    self.required_fields += %i[resource_type institution publisher date_published]
-    self.required_fields -= %i[keyword rights_statement]
+    self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier
+                     related_identifier publisher place_of_publication date_published date_accepted
+                     date_submitted abstract keyword media institution org_unit official_link related_url
+                     related_exhibition related_exhibition_date project_name funder fndr_project_ref
+                     add_info language license rights_statement rights_holder]
   end
 end

--- a/app/forms/hyrax/report_form.rb
+++ b/app/forms/hyrax/report_form.rb
@@ -7,11 +7,10 @@ module Hyrax
     include Ubiquity::EditorMetadataFormBehaviour
 
     self.model_class = ::Report
-    self.terms += %i[resource_type rendering_ids doi series_name volume edition place_of_publication pagination isbn
-                     issn eissn date_published date_accepted date_submitted abstract institution org_unit refereed
-                     official_link project_name funder fndr_project_ref add_info rights_holder]
-    self.terms -= %i[based_near description source subject]
-    self.required_fields += %i[resource_type institution publisher date_published]
-    self.required_fields -= %i[keyword rights_statement]
+    self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier
+                     related_identifier series_name volume edition editor publisher place_of_publication
+                     pagination isbn issn eissn date_published date_accepted date_submitted abstract keyword
+                     institution org_unit refereed official_link related_url project_name
+                     funder fndr_project_ref add_info language license rights_statement rights_holder]
   end
 end

--- a/app/forms/ubiquity/all_forms_shared_behaviour.rb
+++ b/app/forms/ubiquity/all_forms_shared_behaviour.rb
@@ -12,8 +12,28 @@ module Ubiquity
                     :creator_position
 
       attr_accessor :alternate_identifier_group, :related_identifier_group
-      self.terms += %i[alternate_identifier related_identifier]
 
+      # terms inherited from Hyrax::Forms::WorkForm are removed
+      # to then be added at the desired position in each work type form (ex `article_form`)
+      self.terms -= %i[title
+                       creator
+                       contributor
+                       description
+                       keyword
+                       license
+                       rights_statement
+                       publisher
+                       date_created
+                       subject
+                       language
+                       identifier
+                       based_near
+                       related_url
+                       source]
+
+      self.required_fields -= %i[title creator keyword rights_statement]
+      # `title` and `creator` to be removed first then inserted in the desired order
+      self.required_fields += %i[title resource_type creator institution publisher date_published]
     end
 
     class_methods do
@@ -42,6 +62,5 @@ module Ubiquity
     def title
       super.first || ""
     end
-
   end
 end

--- a/app/forms/ubiquity/editor_metadata_form_behaviour.rb
+++ b/app/forms/ubiquity/editor_metadata_form_behaviour.rb
@@ -6,8 +6,6 @@ module Ubiquity
       attr_accessor :editor_group, :editor_name_type, :editor_given_name,
                       :editor_family_name, :editor_orcid, :editor_isni,
                       :editor_position, :editor_organization_name
-
-      self.terms += %i[editor]
     end
 
     class_methods do

--- a/app/views/records/edit_fields/_title.html.erb
+++ b/app/views/records/edit_fields/_title.html.erb
@@ -3,13 +3,14 @@
 <h3 class="ubiquity-title-fail-message" style="color:red;font-weight: 900;"> </h3>
 
 <% my_model_name = f.object.model.class.to_s.underscore %>
+<label class="control-label" for="<% my_model_name %>_title">Title</label>
 <%= text_field_tag "#{my_model_name}[title][]", f.object.model.title.first, id: "#{my_model_name}_title",
   class: "form-control text required form-control ubiquity-title", placeholder: "Add a title", required: "required" %>
 
 
 <%= button_to 'Check title availability', main_app.check_available_ubiquity_titles_path,
    class: "ubiquity-title-checker", data: { 'ubiquity-model' => f.object.model.class.to_s } %>
-
+<br><br>
 <script>
 
   $(document).on("turbolinks:load", function(event){

--- a/app/views/shared/ubiquity/creator/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/creator/_edit_array_hash_form.html.erb
@@ -4,7 +4,6 @@
 <% array_of_hash.each_with_index do |hash, index| %>
 
 <div class="ubiquity-meta-creator" >
-  <%= template == 'collection' %>
   <% if template == 'collection' %>
    <label class="control-label multi_value optional" for="#{template}_creator_name_type">
     Creator name type</label>
@@ -14,7 +13,7 @@
 
   <% else %>
     <label class="control-label multi_value optional" for="#{template}_creator_name_type">
-     Creator name type<span style="color:blue;">required<span></label>
+     Creator name type <span class="label label-info required-tag">required</span></label>
 
      <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("creator_name_type")),
        required: true, class:  'ubiquity_creator_name_type' %>

--- a/app/views/shared/ubiquity/creator/_new_form.html.erb
+++ b/app/views/shared/ubiquity/creator/_new_form.html.erb
@@ -10,7 +10,7 @@
         class: "ubiquity_creator_name_type"  %>
   <% else %>
        <label class="control-label multi_value optional" for="#{template}_creator_name_type">
-          Creator name type<span style="color:blue;">required<span></label>
+          Creator name type <span class="label label-info required-tag">required</span></label>
 
       <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
          required: true, class: "ubiquity_creator_name_type"  %>

--- a/config/locales/article.en.yml
+++ b/config/locales/article.en.yml
@@ -33,6 +33,8 @@ en:
         abstract: Please provide a short abstract or description of the item.
         resource_type: If required, select the specific type of resource that best describes the work; otherwise the default resource type is displayed.
         publisher: The name of the organisation making an article available.
+        keyword: Words or phrases you select to describe what the work is about. These are used to search for content.
+        rights_statement: Please select the most appropriate rights statement for the item.
     labels:
       defaults:
         org_unit: Organisational Unit
@@ -45,3 +47,4 @@ en:
         eissn: eISSN
         isbn: ISBN
         license: Licence
+        keyword: Keywords

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -6,3 +6,7 @@ en:
       generic_work:
         name:               "Generic Work"
         description:        "General purpose work type. Select this if the more specific work types below are not suited to the work you want to add."
+  simple_form:
+    hints:
+      generic_work:
+        resource_type: Select the specific resource type that best describes the work.


### PR DESCRIPTION
... according to BL specs.
Trello Card [#216](https://trello.com/c/06XrzT8Q)

Will address comment from Sara about multi-parts fields separately:
_"For me, having Orcid field and ISNI field separated by name fields doesn't make sense. Orcid & ISNI should sit next to each other. Not actually specced like this as we specced name identifier + id type as the fields and not specifically ISNI & Orcid.
Same with Contributor fields, ORcid & ISNI fields could do with being next to each other."_