### PR TITLE
Reordering of fields on work view

### DIFF
--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -42,7 +42,7 @@ module Hyku
     end
 
     # assumes there can only be one doi
-    def doi
+    def doi_from_identifier
       doi_regex = %r{10\.\d{4,9}\/[-._;()\/:A-Z0-9]+}i
       doi = extract_from_identifier(doi_regex)
       doi.join if doi

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -3,13 +3,13 @@
 <%# display contributor using the show partial  -->
 <%# presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= render "shared/ubiquity/contributor/show", presenter: presenter, source: 'show' %>
-<%= presenter.attribute_to_html(:media, label: "Material/media") %>
 <%= presenter.attribute_to_html(:event_title) %>
 <%= presenter.attribute_to_html(:event_date) %>
 <%= presenter.attribute_to_html(:book_title) %>
 <%= presenter.attribute_to_html(:journal_title, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :resource_type) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:media, label: "Material/media") %>
 <%= presenter.attribute_to_html(:institution) %>
 <%= presenter.attribute_to_html(:date_published, render_as: :linked, search_field: 'date_published_tesim') %>
 <%= presenter.attribute_to_html(:rights_statement) %>
@@ -30,7 +30,7 @@
 <%= presenter.attribute_to_html(:issn, label: "ISSN") %>
 <%= presenter.attribute_to_html(:eissn, label: "eISSN") %>
 <%= presenter.attribute_to_html(:article_num, label: "Article number") %>
-<%= presenter.attribute_to_html(:doi) %>
+<%= presenter.attribute_to_html(:doi, label: "DOI") %>
 <%= presenter.attribute_to_html(:org_unit, label: "Organisational unit") %>
 <%= presenter.attribute_to_html(:project_name) %>
 <%= presenter.attribute_to_html(:version) %>

--- a/app/views/shared/_additional_citations.html.erb
+++ b/app/views/shared/_additional_citations.html.erb
@@ -8,8 +8,8 @@
   <% unless @presenter.publisher.blank? %>
     <meta name="citation_publisher" content="<%= @presenter.publisher.join %>" />
   <% end %>
-  <% unless @presenter.doi.blank? %>
-    <meta name="citation_doi" content="<%= @presenter.doi %>"/>
+  <% unless @presenter.doi_from_identifier.blank? %>
+    <meta name="citation_doi" content="<%= @presenter.doi_from_identifier %>"/>
   <% end %>
   <% unless @presenter.isbns.blank? %>
     <% @presenter.isbns.each do |isbn| %>

--- a/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
+++ b/spec/presenters/hyku/manifest_enabled_work_show_presenter_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
 
   context "when the work has valid doi and isbns" do
     # the values are set in generic_works factory
-    describe "#doi" do
+    describe "#doi_from_identifier" do
       it "extracts the DOI from the identifiers" do
-        expect(presenter.doi).to eq('10.1038/nphys1170')
+        expect(presenter.doi_from_identifier).to eq('10.1038/nphys1170')
       end
     end
 
@@ -80,9 +80,9 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
       { "identifier_tesim" => nil }
     end
 
-    describe "#doi" do
+    describe "#doi_from_identifier" do
       it "is nil" do
-        expect(presenter.doi).to be_nil
+        expect(presenter.doi_from_identifier).to be_nil
       end
     end
 
@@ -110,9 +110,9 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
       { "identifier_tesim" => ['ISBN:978-83-7659-303-6'] }
     end
 
-    describe "#doi" do
+    describe "#doi_from_identifier" do
       it "is empty" do
-        expect(presenter.doi).to be_empty
+        expect(presenter.doi_from_identifier).to be_empty
       end
     end
   end
@@ -123,9 +123,9 @@ RSpec.describe Hyku::ManifestEnabledWorkShowPresenter do
       { "identifier_tesim" => %w[3207/2959859860 svnklvw24 0470841559.ch1] }
     end
 
-    describe "#doi" do
+    describe "#doi_from_identifier" do
       it "is empty" do
-        expect(presenter.doi).to be_empty
+        expect(presenter.doi_from_identifier).to be_empty
       end
     end
 


### PR DESCRIPTION
Change position of "Material/media" field on work show page;
Fix DOI not displaying in work show page.

Follow-up on #66 
Trello [#254](https://trello.com/c/Q70HJFYh)