### PR TITLE
Abstract 'multiple: false'

### DIFF
--- a/app/models/concerns/ubiquity/basic_metadata_decorator.rb
+++ b/app/models/concerns/ubiquity/basic_metadata_decorator.rb
@@ -43,7 +43,7 @@ module Ubiquity
       property :place_of_publication, predicate: ::RDF::Vocab::BF2.term(:Place) do |index|
         index.as :stored_searchable, :facetable
       end
-      property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
+      property :abstract, predicate: ::RDF::Vocab::DC.abstract, multiple: false do |index|
         index.type :text
         index.as :stored_searchable
       end


### PR DESCRIPTION
Abstract metadata field can only be filled in once.