### PR TITLE
revert change to abstract field

### DIFF
--- a/app/models/concerns/ubiquity/basic_metadata_decorator.rb
+++ b/app/models/concerns/ubiquity/basic_metadata_decorator.rb
@@ -43,7 +43,7 @@ module Ubiquity
       property :place_of_publication, predicate: ::RDF::Vocab::BF2.term(:Place) do |index|
         index.as :stored_searchable, :facetable
       end
-      property :abstract, predicate: ::RDF::Vocab::DC.abstract, multiple: false do |index|
+      property :abstract, predicate: ::RDF::Vocab::DC.abstract do |index|
         index.type :text
         index.as :stored_searchable
       end


### PR DESCRIPTION
Revert last commit to be able to access records on live test site and remove data (more than 1 abstract) which breaks on`edit`.