### PR TITLE
Change schema of 'date_submitted' field to avoid conflict with hyrax …

### DIFF
--- a/app/models/concerns/ubiquity/basic_metadata_decorator.rb
+++ b/app/models/concerns/ubiquity/basic_metadata_decorator.rb
@@ -28,7 +28,7 @@ module Ubiquity
       property :date_accepted, predicate: ::RDF::Vocab::DC.dateAccepted, multiple: false do |index|
         index.as :stored_searchable
       end
-      property :date_submitted, predicate: ::RDF::Vocab::DC.dateSubmitted, multiple: false do |index|
+      property :date_submitted, predicate: ::RDF::Vocab::Bibframe.originDate, multiple: false do |index|
         index.as :stored_searchable
       end
       property :project_name, predicate: ::RDF::Vocab::BF2.term(:CollectiveTitle), multiple: false do |index|


### PR DESCRIPTION
…'date_uploaded'

`DC.dateSubmitted` is used by [Hyrax core metadata](https://github.com/samvera/hyrax/blob/master/app/models/concerns/hyrax/core_metadata.rb#L25-L28). It [populates the deposit date](https://github.com/samvera/hyrax/blob/5a9d1be16ee1a9150646384471992b03aab527a5/app/actors/hyrax/actors/base_actor.rb#L63).
The new `date_submitted` field was using the same schema which leads to undesirable behaviour.