### PR TITLE
On the homepage display thumbnail if it exists otherwise display nothing

### DIFF
--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -1,0 +1,44 @@
+<%# Fix to not display default image icon. This file was copied from
+  https://github.com/samvera/hyrax/blob/37a1c370cd05a7ed0a8ca2ad453bc15eb812f132/app/views/hyrax/homepage/_explore_collections.html.erb
+ %>
+
+ <table class="table table-striped collection-highlights">
+  <tbody>
+    <% collections.each do |collection| %>
+      <%# collection.inspect %>
+
+      <tr>
+        <td>
+          <div class="media">
+            <!-- if condition added by ubiquity to display image or empty border but not default icon-->
+            <% if collection.thumbnail_id %>
+            <%= link_to [hyrax, collection], class: 'media-left', 'aria-hidden' => true do %>
+                <%= render_thumbnail_tag collection, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+            <% end %>
+            <% else %>
+               <%= link_to [hyrax, collection], class: 'media-left', 'aria-hidden' => true do %>
+                   <span class="media-left" aria-hidden="true" href="#" style="border: 52px solid transparent;"> </span>
+               <% end %>
+
+            <% end %>
+
+            <div class="media-body">
+              <div class="media-heading">
+                <%= link_to [hyrax, collection] do %>
+                  <%= collection.title_or_label %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<ul class="list-inline collection-highlights-list">
+  <li>
+    <%= link_to t('hyrax.homepage.admin_sets.link'),
+                main_app.search_catalog_path(f: { human_readable_type_sim: ["Collection"]}),
+                class: 'btn btn-default' %>
+  </li>
+</ul>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,0 +1,23 @@
+<%# Fix to not display default image icon. This file was copied from
+  https://github.com/samvera/hyrax/blob/37a1c370cd05a7ed0a8ca2ad453bc15eb812f132/app/views/hyrax/homepage/_recent_document.html.erb
+ %>
+
+<tr>
+    <td class="col-sm-2">
+      <%= link_to_profile recent_document.depositor("no depositor value") %>
+      <!-- if condition added by ubiquity to ensure default thumbnail is not displayed-->
+      <%if  recent_document.thumbnail_id %>
+        <%= link_to [main_app, recent_document] do %>
+          <%= render_thumbnail_tag recent_document, { width: 45 }, suppress_link: true %>
+        <% end %>
+      <% end %>
+    </td>
+    <td>
+      <h3>
+        <span class="sr-only">Title</span><%= link_to truncate(recent_document.to_s, length: 28, separator: ' '), [main_app, recent_document] %>
+      </h3>
+      <p>
+        <span class="sr-only">Keywords</span><%= link_to_facet_list(recent_document.keyword, 'keyword', 'no keywords specified').html_safe %>
+      </p>
+    </td>
+  </tr>


### PR DESCRIPTION
On the homepage display thumbnail if it exists otherwise display nothing.
Trello: https://trello.com/c/yEaeUHma/286-remove-default-icons-from-home-page

Old homepage display showing default icons:
![image](https://user-images.githubusercontent.com/329514/45966355-c6b56d80-c022-11e8-9a98-9bd75b9996f7.png)

New display without default thumbnail:
![image](https://user-images.githubusercontent.com/329514/45966401-eba9e080-c022-11e8-9c13-316214eeecb4.png)
