### PR TITLE
Additional logic needed to display custom "Resource Type" metadata

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -52,7 +52,7 @@ class CatalogController < ApplicationController
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
     # config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5
-    config.add_facet_field solr_name("resource_type", :facetable), helper_method: :human_readable_resource_type, label: "Resource Type", limit: 5
+    config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
     config.add_facet_field solr_name("creator", :facetable), limit: 5
     # config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5
     config.add_facet_field solr_name("keyword", :facetable), limit: 5

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -52,7 +52,7 @@ class CatalogController < ApplicationController
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
     # config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5
-    config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5
+    config.add_facet_field solr_name("resource_type", :facetable), helper_method: :human_readable_resource_type, label: "Resource Type", limit: 5
     config.add_facet_field solr_name("creator", :facetable), limit: 5
     # config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5
     config.add_facet_field solr_name("keyword", :facetable), limit: 5

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,14 +15,12 @@ module ApplicationHelper
   end
 
   # override from blacklight/app/helpers/blacklight/facets_helper_behavior.rb
-  def render_facet_partials fields = facet_field_names, options = {}
-    safe_join(facets_from_request(fields).map do |display_facet|
-      if display_facet.name == "resource_type_sim"
-        display_facet.items.each do |i|
-          i[:value] = human_readable_resource_type(i[:value])
-        end
+  def render_facet_limit(display_facet, options = {})
+    if display_facet.name == "resource_type_sim"
+      display_facet.items.each do |i|
+        i[:value] = human_readable_resource_type(i[:value])
       end
-      render_facet_limit(display_facet, options)
-    end.compact, "\n")
+    end
+    super
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,16 @@ module ApplicationHelper
     field.delete("[{}]")
     field.present?
   end
+
+  # override from blacklight/app/helpers/blacklight/facets_helper_behavior.rb
+  def render_facet_partials fields = facet_field_names, options = {}
+    safe_join(facets_from_request(fields).map do |display_facet|
+      if display_facet.name == "resource_type_sim"
+        display_facet.items.each do |i|
+          i[:value] = human_readable_resource_type(i[:value])
+        end
+      end
+      render_facet_limit(display_facet, options)
+    end.compact, "\n")
+  end
 end

--- a/app/helpers/ubiquity/solr_search_display_helpers.rb
+++ b/app/helpers/ubiquity/solr_search_display_helpers.rb
@@ -21,8 +21,10 @@ module Ubiquity
 
     # remove the model name (i.e. "Collection" or "GenericWork") and "default";
     # `type` is the id in config/authorities/resources_types.yml
+    # @see CatalogController
+    # a [Hash] is passed in index_field, whereas a [String] is passed in facet_field
     def human_readable_resource_type(options={})
-      type = options[:value]
+      type = options.is_a?(Hash) ? options[:value] : [options]
       readable_type = []
       type.each do |t|
         e = t.split.drop(1)


### PR DESCRIPTION
Trello #[264](https://trello.com/c/7EieLDwA)

Terms for the "Resource Type" metadata field are customised per model, thus we need to handle the display where the default produces the term id, i.e. "Article default Journal article" instead of "Journal article".
previous: 
![screenshot from 2018-09-27 13-37-22](https://user-images.githubusercontent.com/26539307/46149062-59dbe680-c261-11e8-8217-cc714a39c87c.png)

now:
![screenshot from 2018-09-27 14-28-02](https://user-images.githubusercontent.com/26539307/46149170-9c052800-c261-11e8-9d54-0dfe2010b5f9.png)

Linked to #30 , #57 