### PR TITLE
Various fix to work and search result page. Including ensuring isni a…

### DIFF
--- a/app/helpers/multiple_metadata_fields_helper.rb
+++ b/app/helpers/multiple_metadata_fields_helper.rb
@@ -16,13 +16,15 @@ module MultipleMetadataFieldsHelper
 
   #Here we are checking in the works and search result page if the hash_keys for json fields
   # include values for either isni or orcid before displaying parenthesis
-  def should_parenthesis_be_displayed(hash_keys, valid_keys)
+  #def should_parenthesis_be_displayed(hash_keys, valid_keys)
+  def display_paren?(hash_keys, valid_keys)
     (hash_keys & valid_keys).any?
   end
 
   #Here we are checking in the works and search result page if the hash_keys for json fields
   # include a subset that is an array that includes either isni or orcid alongside contributor type before displaying a comma
-  def should_comma_be_diplayed(hash_keys, valid_keys)
+  #def should_comma_be_diplayed(hash_keys, valid_keys)
+  def display_comma?(hash_keys, valid_keys)
     all_keys_set = hash_keys.to_set
     if valid_keys == ["contributor_type", "contributor_orcid", "contributor_isni"]
       keys_with_orcid_id = valid_keys.take(2)

--- a/app/helpers/multiple_metadata_fields_helper.rb
+++ b/app/helpers/multiple_metadata_fields_helper.rb
@@ -16,14 +16,12 @@ module MultipleMetadataFieldsHelper
 
   #Here we are checking in the works and search result page if the hash_keys for json fields
   # include values for either isni or orcid before displaying parenthesis
-  #def should_parenthesis_be_displayed(hash_keys, valid_keys)
   def display_paren?(hash_keys, valid_keys)
     (hash_keys & valid_keys).any?
   end
 
   #Here we are checking in the works and search result page if the hash_keys for json fields
   # include a subset that is an array that includes either isni or orcid alongside contributor type before displaying a comma
-  #def should_comma_be_diplayed(hash_keys, valid_keys)
   def display_comma?(hash_keys, valid_keys)
     all_keys_set = hash_keys.to_set
     if valid_keys == ["contributor_type", "contributor_orcid", "contributor_isni"]

--- a/app/helpers/multiple_metadata_fields_helper.rb
+++ b/app/helpers/multiple_metadata_fields_helper.rb
@@ -1,7 +1,39 @@
 module MultipleMetadataFieldsHelper
 
-  def dont_display_empty_brackets(hash_keys, valid_keys)
+  #Only the id of isni and orcid are saved in the database, hence we are using that to create the full url for clickable links
+  #in the works and search result page
+  def render_isni_or_orcid_url(id, type)
+    if type == 'orcid'
+      host = URI('https://orcid.org/')
+      host.path = "/#{id}"
+      host.to_s
+    else
+      host = URI('http://www.isni.org')
+      host.path = "/isni/#{id}"
+      host.to_s
+    end
+  end
+
+  #Here we are checking in the works and search result page if the hash_keys for json fields
+  # include values for either isni or orcid before displaying parenthesis
+  def should_parenthesis_be_displayed(hash_keys, valid_keys)
     (hash_keys & valid_keys).any?
+  end
+
+  #Here we are checking in the works and search result page if the hash_keys for json fields
+  # include a subset that is an array that includes either isni or orcid alongside contributor type before displaying a comma
+  def should_comma_be_diplayed(hash_keys, valid_keys)
+    all_keys_set = hash_keys.to_set
+    if valid_keys == ["contributor_type", "contributor_orcid", "contributor_isni"]
+      keys_with_orcid_id = valid_keys.take(2)
+      keys_with_isni_id = [valid_keys.first, valid_keys.last]
+      array_with_orcid_id_set = keys_with_orcid_id.to_set
+      array_with_isni_id_set = keys_with_isni_id.to_set
+      array_with_orcid_id_set.subset? all_keys_set or array_with_isni_id_set.subset? all_keys_set
+    else
+      needed_keys_set = valid_keys.to_set
+      needed_keys_set.subset? all_keys_set
+    end
   end
 
   def get_model(model_class, model_id, field, multipart_sort_field_name = nil)

--- a/app/helpers/ubiquity/solr_search_display_helpers.rb
+++ b/app/helpers/ubiquity/solr_search_display_helpers.rb
@@ -31,13 +31,5 @@ module Ubiquity
       end
       readable_type.join(', ')
     end
-
-    private
-
-      def pass_model(options)
-        my_model = options[:document].hydra_model.to_s
-        my_id = options[:document].id
-        presento ||= Ubiquity::SolrModelWrapper.new(my_model, my_id)
-      end
   end
 end

--- a/app/views/shared/ubiquity/contributor/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/contributor/_show_array_hash.html.erb
@@ -10,14 +10,13 @@
                 <%= hash['contributor_organization_name'] %>
               <% end %>
               <% if hash['contributor_family_name'].present? %>
-
                 <%= hash['contributor_family_name'] %>
                 <% if display_comma?(hash.keys, ["contributor_family_name", "contributor_given_name"]) %> , <% end %> &nbsp;
-                <% end %>
-                <% if hash['contributor_given_name'].present? %>
-                  <%= hash['contributor_given_name'] %>
-                <% end %>
-              </span>
+              <% end %>
+              <% if hash['contributor_given_name'].present? %>
+                <%= hash['contributor_given_name'] %>
+              <% end %>
+             </span>
 
               <span itemprop="name">
                 <% if display_paren?(hash.keys, ["contributor_isni", "contributor_orcid", "contributor_type"]) %>

--- a/app/views/shared/ubiquity/contributor/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/contributor/_show_array_hash.html.erb
@@ -7,11 +7,12 @@
 
             <span style="float:left">
               <% if hash['contributor_organization_name'] %>
-                <%= hash['contributor_organization_name'] %> 
+                <%= hash['contributor_organization_name'] %>
               <% end %>
               <% if hash['contributor_family_name'].present? %>
 
-                <%= hash['contributor_family_name'] %> <% if should_comma_be_diplayed(hash.keys, ["contributor_family_name", "contributor_given_name"]) %> , <% end %> &nbsp;
+                <%= hash['contributor_family_name'] %>
+                <% if display_comma?(hash.keys, ["contributor_family_name", "contributor_given_name"]) %> , <% end %> &nbsp;
                 <% end %>
                 <% if hash['contributor_given_name'].present? %>
                   <%= hash['contributor_given_name'] %>
@@ -19,11 +20,11 @@
               </span>
 
               <span itemprop="name">
-                <% if should_parenthesis_be_displayed(hash.keys, ["contributor_isni", "contributor_orcid", "contributor_type"]) %>
+                <% if display_paren?(hash.keys, ["contributor_isni", "contributor_orcid", "contributor_type"]) %>
                   <span style="float:left" > &nbsp;(</span>
                   <span style="float:left">
                     <% if hash['contributor_type'].present? %>
-                      <%= hash['contributor_type'] %>  <% if should_comma_be_diplayed(hash.keys, ["contributor_type", "contributor_orcid", "contributor_isni"]) %> , &nbsp; <% end %>
+                      <%= hash['contributor_type'] %>  <% if display_comma?(hash.keys, ["contributor_type", "contributor_orcid", "contributor_isni"]) %> , &nbsp; <% end %>
                     <% end %>
                   </span>
 

--- a/app/views/shared/ubiquity/contributor/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/contributor/_show_array_hash.html.erb
@@ -1,17 +1,17 @@
 <tr>
-     <th>Contributors</th>
-   <% array_of_hash.each do |hash| %>
-      <td style="display:inline">
-        <ul class="tabular">
+  <th>Contributor</th>
+  <td>
+    <ul class="tabular">
+      <% array_of_hash.each do |hash| %>
           <li class="attribute contributor">
 
             <span style="float:left">
               <% if hash['contributor_organization_name'] %>
-                <%= hash['contributor_organization_name'] %>,&nbsp;
+                <%= hash['contributor_organization_name'] %> 
               <% end %>
               <% if hash['contributor_family_name'].present? %>
 
-                <%= hash['contributor_family_name'] %> ,&nbsp;
+                <%= hash['contributor_family_name'] %> <% if should_comma_be_diplayed(hash.keys, ["contributor_family_name", "contributor_given_name"]) %> , <% end %> &nbsp;
                 <% end %>
                 <% if hash['contributor_given_name'].present? %>
                   <%= hash['contributor_given_name'] %>
@@ -19,37 +19,35 @@
               </span>
 
               <span itemprop="name">
-                <% if dont_display_empty_brackets(hash.keys, ["contributor_isni", "contributor_orcid", "contributor_type"]) %>
+                <% if should_parenthesis_be_displayed(hash.keys, ["contributor_isni", "contributor_orcid", "contributor_type"]) %>
                   <span style="float:left" > &nbsp;(</span>
                   <span style="float:left">
                     <% if hash['contributor_type'].present? %>
-                      <%= hash['contributor_type'] %>,  &nbsp;
+                      <%= hash['contributor_type'] %>  <% if should_comma_be_diplayed(hash.keys, ["contributor_type", "contributor_orcid", "contributor_isni"]) %> , &nbsp; <% end %>
                     <% end %>
                   </span>
 
                   <% if hash['contributor_orcid'].present? %>
-                      <a  href="<%= hash['contributor_orcid'] %>" target="_blank" >
+                        <% orcid_id = hash['contributor_orcid'] %>
+                        <a href='<%= render_isni_or_orcid_url("#{orcid_id}", "orcid") %>'  target="_blank">
                         <img src="https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/orcid_16x16.png" alt="orcid"  height="16" width="16" class="img-responsive" style="float:left"  >
                       </a>
                    <% end %>
 
                     <% if hash['contributor_isni'].present? %>
-                      <a  href="<%= hash['contributor_isni'] %>" target="_blank" >
+                       <% isni_id = hash['contributor_isni'] %>
+                       <a href='<%= render_isni_or_orcid_url("#{isni_id}", "isni") %>'  target="_blank">
                        <img src="
                           https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/logo_xml_isni-16.gif" alt="orcid"  height="16" width="44" class="img-responsive" style="float:left"  >
                        </a>
                     <% end %>
-                    <span style="float:left">)<span>
+                    <span>)</span>
                  <% end %>
                </span>
 
-               <span itemprop="name">
-              </span>
-
             </li>
-        </ul>
-        </td>
 
-    <% end %>
-
+      <% end %>
+    </ul>
+  </td>
 </tr>

--- a/app/views/shared/ubiquity/creator/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/creator/_show_array_hash.html.erb
@@ -7,10 +7,11 @@
 
            <span style="float:left">
              <% if hash['creator_organization_name'] %>
-               <%= hash['creator_organization_name'] %> 
+               <%= hash['creator_organization_name'] %>
              <% end %>
              <% if hash['creator_family_name']  %>
-               <%= hash['creator_family_name'] %> <% if should_comma_be_diplayed(hash.keys, ["creator_family_name", "creator_given_name"]) %> , <% end %> &nbsp;
+               <%= hash['creator_family_name'] %>
+               <% if display_comma?(hash.keys, ["creator_family_name", "creator_given_name"]) %> , <% end %> &nbsp;
              <% end %>
              <% if hash['creator_given_name'] %>
                <%= hash['creator_given_name'] %>
@@ -18,7 +19,7 @@
            </span>
 
             <span itemprop="name">
-             <% if should_parenthesis_be_displayed(hash.keys, ["creator_orcid", 'creator_isni']) %>
+             <% if display_paren?(hash.keys, ["creator_orcid", 'creator_isni']) %>
                <span style="float:left" > &nbsp;(</span>
                  <% if hash['creator_orcid'].present? %>
                    <% orcid_id = hash['creator_orcid'] %>

--- a/app/views/shared/ubiquity/creator/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/creator/_show_array_hash.html.erb
@@ -1,50 +1,46 @@
 <tr>
+  <th>Creator</th>
+  <td>
+    <ul class="tabular">
+      <% array_of_hash.each do |hash| %>
+         <li class="attribute creator">
 
-    <th>Creators</th>
-
-   <% array_of_hash.each do |hash| %>
-
-      <td style="display:inline">
-        <ul class="tabular">
-          <li class="attribute creator">
-
-            <span style="float:left">
-              <% if hash['creator_organization_name'] %>
-                <%= hash['creator_organization_name'] %>,&nbsp;
-              <% end %>
-              <% if hash['creator_family_name']  %>
-                <%= hash['creator_family_name'] %>,&nbsp;
-              <% end %>
-              <% if hash['creator_given_name'] %>
-                <%= hash['creator_given_name'] %>
-              <% end %>
-            </span>
+           <span style="float:left">
+             <% if hash['creator_organization_name'] %>
+               <%= hash['creator_organization_name'] %> 
+             <% end %>
+             <% if hash['creator_family_name']  %>
+               <%= hash['creator_family_name'] %> <% if should_comma_be_diplayed(hash.keys, ["creator_family_name", "creator_given_name"]) %> , <% end %> &nbsp;
+             <% end %>
+             <% if hash['creator_given_name'] %>
+               <%= hash['creator_given_name'] %>
+             <% end %>
+           </span>
 
             <span itemprop="name">
-              <% if dont_display_empty_brackets(hash.keys, ["creator_orcid", 'creator_isni']) %>
-                <span style="float:left" > &nbsp;(</span>
-                  <% if hash['creator_orcid'].present? %>
-                    <a  href="<%= hash['creator_orcid'] %>" target="_blank" >
-                     <img src="https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/orcid_16x16.png" alt="ORCID"  height="16" width="16" class="img-responsive"  style="float:left"  >
+             <% if should_parenthesis_be_displayed(hash.keys, ["creator_orcid", 'creator_isni']) %>
+               <span style="float:left" > &nbsp;(</span>
+                 <% if hash['creator_orcid'].present? %>
+                   <% orcid_id = hash['creator_orcid'] %>
+                   <a href='<%= render_isni_or_orcid_url("#{orcid_id}", "orcid") %>'  target="_blank">
+                    <img src="https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/orcid_16x16.png" alt="ORCID"  height="16" width="16" class="img-responsive"  style="float:left"  >
+                  </a>
+                <% end %>
+
+                <% if hash['creator_isni'].present? %>
+                   <% isni_id = hash['creator_isni'] %>
+                   <a href='<%= render_isni_or_orcid_url("#{isni_id}", "isni") %>'  target="_blank">
+                   <img src="
+                      https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/logo_xml_isni-16.gif" alt="ISNI"  height="16" width="44" class="img-responsive" style="float:left"  >
                    </a>
                  <% end %>
-
-                 <% if hash['creator_isni'].present? %>
-                   <a  href="<%= hash['creator_isni'] %>" target="_blank" >
-                    <img src="
-                       https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/logo_xml_isni-16.gif" alt="ISNI"  height="16" width="44" class="img-responsive" style="float:left"  >
-                    </a>
-                  <% end %>
-                <span style="float:left">)<span>
-              <% end %>
+               <span>)</span>
+             <% end %>
             </span>
 
-            <span itemprop="name">
-            </span>
-            </li>
-        </ul>
-        </td>
+           </li>
 
-    <% end %>
-
+     <% end %>
+   </ul>
+  </td>
 </tr>

--- a/app/views/shared/ubiquity/editor/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/editor/_show_array_hash.html.erb
@@ -10,7 +10,8 @@
                 <%= hash['editor_organization_name'] %>
               <% end %>
               <% if hash['editor_family_name'] %>
-                <%= hash['editor_family_name'] %> <% if should_comma_be_diplayed(hash.keys, ["editor_family_name", "editor_given_name"]) %> , <% end %> &nbsp;
+                <%= hash['editor_family_name'] %>
+                <% if display_comma?(hash.keys, ["editor_family_name", "editor_given_name"]) %> , <% end %> &nbsp;
               <% end %>
               <% if hash['editor_given_name'] %>
                 <%= hash['editor_given_name'] %>
@@ -18,7 +19,7 @@
             </span>
 
             <span itemprop="name">
-              <% if should_parenthesis_be_displayed(hash.keys, ["editor_orcid", 'editor_isni']) %>
+              <% if display_paren?(hash.keys, ["editor_orcid", 'editor_isni']) %>
                 <span style="float:left" > &nbsp;(</span>
                    <% if hash['editor_orcid'].present? %>
                        <% orcid_id = hash['editor_orcid'] %>

--- a/app/views/shared/ubiquity/editor/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/editor/_show_array_hash.html.erb
@@ -1,18 +1,16 @@
 <tr>
-    <th>Editors</th>
-
-   <% array_of_hash.each do |hash| %>
-
-      <td style="display:inline">
-        <ul class="tabular">
+    <th>Editor</th>
+    <td>
+      <ul class="tabular">
+        <% array_of_hash.each do |hash| %>
           <li class="attribute editor">
 
             <span style="float:left">
               <% if hash['editor_organization_name'] %>
-                <%= hash['editor_organization_name'] %>,&nbsp;
+                <%= hash['editor_organization_name'] %>
               <% end %>
               <% if hash['editor_family_name'] %>
-                <%= hash['editor_family_name'] %>,&nbsp;
+                <%= hash['editor_family_name'] %> <% if should_comma_be_diplayed(hash.keys, ["editor_family_name", "editor_given_name"]) %> , <% end %> &nbsp;
               <% end %>
               <% if hash['editor_given_name'] %>
                 <%= hash['editor_given_name'] %>
@@ -20,27 +18,27 @@
             </span>
 
             <span itemprop="name">
-              <% if dont_display_empty_brackets(hash.keys, ["editor_orcid", 'editor_isni']) %>
+              <% if should_parenthesis_be_displayed(hash.keys, ["editor_orcid", 'editor_isni']) %>
                 <span style="float:left" > &nbsp;(</span>
                    <% if hash['editor_orcid'].present? %>
-                     <a  href="<%= hash['editor_orcid'] %>" target="_blank" >
+                       <% orcid_id = hash['editor_orcid'] %>
+                       <a href='<%= render_isni_or_orcid_url("#{orcid_id}", "orcid") %>'  target="_blank">
                        <img src="https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/orcid_16x16.png" alt="orcid"  height="16" width="16" class="img-responsive" style="float:left">
                      </a>
                    <% end %>
 
                   <% if hash['editor_isni'].present? %>
-                    <a  href="<%= hash['editor_isni'] %>" target="_blank" >
+                      <% isni_id = hash['editor_isni'] %>
+                      <a href='<%= render_isni_or_orcid_url("#{isni_id}", "isni") %>'  target="_blank">
                       <img src="
                        https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/logo_xml_isni-16.gif" alt="orcid"  height="16" width="44" class="img-responsive" style="float:left"  >
                      </a>
                      <% end %>
-                   <span style="float:left">)<span>
+                   <span>)</span>
                   <% end %>
                 </span>
             </li>
-        </ul>
-        </td>
-
-    <% end %>
-
+      <% end %>
+    </ul>
+  </td>
 </tr>

--- a/app/views/shared/ubiquity/search_display/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/search_display/_show_array_hash.html.erb
@@ -1,31 +1,31 @@
-
-
 <td>
    <% array_of_hash.each do |hash| %>
-          <span itemprop='<%= "#{attr_name}" %>' style="float:left">
-              <% if hash["#{attr_name}_organization_name"] %>
-                <%= hash["#{attr_name}_organization_name"] %>,&nbsp;
-              <% end %>
-              <% if hash["#{attr_name}_family_name"]  %>
-                <%= hash["#{attr_name}_family_name"] %>,&nbsp;
-              <% end %>
-              <% if hash["#{attr_name}_given_name"] %>
-                <%= hash["#{attr_name}_given_name"] %>
-              <% end %>
+        <span itemprop='<%= "#{attr_name}" %>' style="float:left">
+          <% if hash["#{attr_name}_organization_name"] %>
+            <%= hash["#{attr_name}_organization_name"] %>
+          <% end %>
+          <% if hash["#{attr_name}_family_name"]  %>
+            <%= hash["#{attr_name}_family_name"] %> <% if should_comma_be_diplayed(hash.keys, ["#{attr_name}_family_name", "#{attr_name}_given_name"]) %> , &nbsp;<% end %>
+          <% end %>
+          <% if hash["#{attr_name}_given_name"] %>
+            <%= hash["#{attr_name}_given_name"] %>
+          <% end %>
         </span>
 
         <span itemprop='<%= "#{attr_name}" %>'>
-         <% if dont_display_empty_brackets(hash.keys, ["#{attr_name}_orcid", "#{attr_name}_isni"]) %>
+         <% if should_parenthesis_be_displayed(hash.keys, ["#{attr_name}_orcid", "#{attr_name}_isni"]) %>
            <span style="float:left" > &nbsp;(</span>
              <% if hash["#{attr_name}_orcid"].present? %>
-               <a  href='<%= hash["#{attr_name}_orcid"] %>' target="_blank" >
-                <img src="https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/orcid_16x16.png" alt="ORCID"  height="16" width="16" class="img-responsive"  style="float:left"  >
-              </a>
-            <% end %>
+               <% orcid_id = hash["#{attr_name}_orcid"] %>
+               <a href='<%= render_isni_or_orcid_url("#{orcid_id}", "orcid") %>'  target="_blank">
+                 <img src="https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/orcid_16x16.png" alt="ORCID"  height="16" width="16" class="img-responsive"  style="float:left"  >
+               </a>
+             <% end %>
 
             <% if hash["#{attr_name}_isni"].present? %>
-              <a  href='<%= hash['#{attr_name}_isni'] %>' target="_blank" >
-               <img src="
+              <% isni_id = hash["#{attr_name}_isni"] %>
+              <a href='<%= render_isni_or_orcid_url("#{isni_id}", "isni") %>'  target="_blank">
+                <img src="
                   https://s3.eu-west-2.amazonaws.com/ox-dev/ubi/logo_xml_isni-16.gif" alt="ISNI"  height="16" width="44" class="img-responsive" style="float:left"  >
                </a>
              <% end %>

--- a/app/views/shared/ubiquity/search_display/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/search_display/_show_array_hash.html.erb
@@ -5,7 +5,8 @@
             <%= hash["#{attr_name}_organization_name"] %>
           <% end %>
           <% if hash["#{attr_name}_family_name"]  %>
-            <%= hash["#{attr_name}_family_name"] %> <% if should_comma_be_diplayed(hash.keys, ["#{attr_name}_family_name", "#{attr_name}_given_name"]) %> , &nbsp;<% end %>
+            <%= hash["#{attr_name}_family_name"] %>
+            <% if display_comma?(hash.keys, ["#{attr_name}_family_name", "#{attr_name}_given_name"]) %> , &nbsp;<% end %>
           <% end %>
           <% if hash["#{attr_name}_given_name"] %>
             <%= hash["#{attr_name}_given_name"] %>
@@ -13,7 +14,7 @@
         </span>
 
         <span itemprop='<%= "#{attr_name}" %>'>
-         <% if should_parenthesis_be_displayed(hash.keys, ["#{attr_name}_orcid", "#{attr_name}_isni"]) %>
+         <% if display_paren?(hash.keys, ["#{attr_name}_orcid", "#{attr_name}_isni"]) %>
            <span style="float:left" > &nbsp;(</span>
              <% if hash["#{attr_name}_orcid"].present? %>
                <% orcid_id = hash["#{attr_name}_orcid"] %>

--- a/config/authorities/contributor_group.yml
+++ b/config/authorities/contributor_group.yml
@@ -20,4 +20,42 @@ terms:
  - id: Hosting Institution
    term: Hosting Institution
    active: true
-
+ - id: Producer
+   term: Producer
+   active: true
+ - id: Project Leader
+   term: Project Leader
+   active: true
+ - id: Project Manager
+   term: Project Manager
+   active: true
+ - id: Project Member
+   term: Project Member
+   active: true
+ - id: Registration Agency
+   term: Registration Agency
+   active: true
+ - id: Registration Authority
+   term: Registration Authority
+   active: true
+ - id: Related Person
+   term: Related Person
+   active: true
+ - id: Researcher
+   term: Researcher
+   active: true
+ - id: Research Group
+   term: Research Group
+   active: true
+ - id: Rights Holder
+   term: Rights Holder
+   active: true
+ - id: Sponsor Supervisor
+   term: Sponsor Supervisor
+   active: true
+ - id: Work Package Leader
+   term: Work Package Leader
+   active: true
+ - id : Other
+   term: Other
+   active:  true  


### PR DESCRIPTION
The following Trello cards are resolved by this pull request:

ORCID and ISNI link now working
 https://trello.com/c/cdmyDGgc/201-05-template-testing-orcid-and-isni-link-out-do-not-work

Comma ',', is no more diplayed when organisational name used for creator, contributor and editor
 https://trello.com/c/a8zsFtFm/220-01-template-testing-public-view-if-organisational-name-used-comma-is-added-after-the-name-as-if-first-name-last-name-eg-british

This ' _ ' symbol has been removed and no longer shown next to creator, contributor and editor names in 'Descriptions' metadata
 https://trello.com/c/bL2ntxTv/208-01-template-testing-public-view-symbol-shown-next-to-creator-contributor-and-editor-names-in-descriptions-metadata

The comma between 'contributor type' and the ORCID/ISNI is now dependent on the presence of 'ORCID OR ISNI' AND a 'contributor type'
 https://trello.com/c/nhjcpoYw/222-025-template-testing-public-view-make-the-comma-between-contributor-type-and-the-orcid-isni-dependent-on-the-presence-of-orcid 

Field labels for Creator, Contributor and Editor no longer have an 'S' on the end of the word
  https://trello.com/c/age7XMxm/217-01-testing-failed-template-testing-public-view-field-labels-for-creator-contributor-and-editor-all-need-to-begin-with-a-capital

Full list of contributor type
  https://trello.com/c/ohSIoyO6/200-01-template-testing-full-list-of-contributor-types-is-not-currently-in-any-work-type

