### PR TITLE
Remove 'super'

### DIFF
--- a/app/controllers/concerns/ubiquity/breadcrumb_override.rb
+++ b/app/controllers/concerns/ubiquity/breadcrumb_override.rb
@@ -13,7 +13,6 @@ module Ubiquity
         add_breadcrumb_for_controller if user_signed_in?
         add_breadcrumb_for_action if user_signed_in?
       end
-      super
     end
   end
 end


### PR DESCRIPTION
Fixes double display of breadcrumb trail for logged in users. Following #93 