### PR TITLE
External URLs to open in a new tab, remove icon

### DIFF
--- a/app/renderers/hyrax/renderers/external_url_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/external_url_attribute_renderer.rb
@@ -1,0 +1,20 @@
+class ExternalUrlAttributeRenderer < Hyrax::Renderers::AttributeRenderer
+  def render
+    markup = ''
+    values.delete("") if values # delete an empty string in array or it would display
+    return markup if values.blank? && !options[:include_empty]
+    link = values.is_a?(Array) ? values.join : values
+    li_value(link)
+  end
+
+  private
+
+  def li_value(value)
+    markup = %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
+    attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
+    markup << "<li#{html_attributes(attributes)}>"
+    markup << auto_link(value, html: { target: '_blank' })
+    markup << %(</li></ul></td></tr>)
+    markup.html_safe
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -15,7 +15,7 @@
 <%= presenter.attribute_to_html(:media, label: "Material/media") %>
 <%= presenter.attribute_to_html(:institution) %>
 <%= presenter.attribute_to_html(:date_published) %>
-<%= presenter.attribute_to_html(:rights_statement) %>
+<%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement) %>
 <%= presenter.attribute_to_html(:abstract, render_as: :string) %>
 <%= presenter.attribute_to_html(:related_exhibition) %>
 <%= presenter.attribute_to_html(:related_exhibition_date) %>
@@ -35,7 +35,7 @@
 <%= presenter.attribute_to_html(:issn, label: "ISSN", render_as: :string) %>
 <%= presenter.attribute_to_html(:eissn, label: "eISSN", render_as: :string) %>
 <%= presenter.attribute_to_html(:article_num, label: "Article number") %>
-<%= presenter.attribute_to_html(:doi, label: "DOI", render_as: :string) %>
+<%= presenter.attribute_to_html(:doi, label: "DOI", render_as: :external_url) %>
 <%= presenter.attribute_to_html(:org_unit, label: "Organisational unit") %>
 <%= presenter.attribute_to_html(:project_name, render_as: :string) %>
 <%= presenter.attribute_to_html(:version) %>
@@ -43,8 +43,8 @@
 <%= presenter.attribute_to_html(:fndr_project_ref, label: "Funder project reference") %>
 <%= presenter.attribute_to_html(:date_accepted, render_as: :string) %>
 <%= presenter.attribute_to_html(:add_info, label: "Additional Information", render_as: :string) %>
-<%= presenter.attribute_to_html(:official_link, render_as: :external_link, render_as: :string) %>
-<%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
+<%= presenter.attribute_to_html(:official_link, render_as: :external_url) %>
+<%= presenter.attribute_to_html(:related_url, render_as: :external_url) %>
 <%= presenter.attribute_to_html(:rights_holder) %>
 <%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true, label: "Licence") %>
 <!-- Future refactoring: can we achieve this below with an AlternateIdentifierAttributeRenderer in app/renderers -->


### PR DESCRIPTION
Trello #[226](https://trello.com/c/qLL8hEl6)

- Rights Statement - draws from `hyrax/app/renderers/hyrax/renderers/rights_statement_attribute_renderer.rb`

Custom renderer for:
- Official link
- Related URL
- DOI