### PR TITLE
Display "Official URL" instead of "Official link"

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -43,8 +43,8 @@
 <%= presenter.attribute_to_html(:fndr_project_ref, label: "Funder project reference") %>
 <%= presenter.attribute_to_html(:date_accepted, render_as: :string) %>
 <%= presenter.attribute_to_html(:add_info, label: "Additional Information", render_as: :string) %>
-<%= presenter.attribute_to_html(:official_link, render_as: :external_url) %>
-<%= presenter.attribute_to_html(:related_url, render_as: :external_url) %>
+<%= presenter.attribute_to_html(:official_link, render_as: :external_url, label: "Offical URL") %>
+<%= presenter.attribute_to_html(:related_url, render_as: :external_url, label: "Related URL") %>
 <%= presenter.attribute_to_html(:rights_holder) %>
 <%= presenter.attribute_to_html(:license, render_as: :license, html_dl: true, label: "Licence") %>
 <!-- Future refactoring: can we achieve this below with an AlternateIdentifierAttributeRenderer in app/renderers -->

--- a/config/locales/conference_item.en.yml
+++ b/config/locales/conference_item.en.yml
@@ -50,3 +50,5 @@ en:
         eissn: eISSN
         isbn: ISBN
         license: Licence
+        official_link: Official URL
+        related_url: Related URL

--- a/config/locales/dataset.en.yml
+++ b/config/locales/dataset.en.yml
@@ -47,3 +47,5 @@ en:
         eissn: eISSN
         isbn: ISBN
         license: Licence
+        official_link: Official URL
+        related_url: Related URL

--- a/config/locales/report.en.yml
+++ b/config/locales/report.en.yml
@@ -45,3 +45,5 @@ en:
         eissn: eISSN
         isbn: ISBN
         license: Licence
+        official_link: Official URL
+        related_url: Related URL


### PR DESCRIPTION
Trello #[242](https://trello.com/c/VnhetPtg)

Label "Official `URL`" (instead of 'link')
and "Related `URL`'"(instead or lower case 'url').