### PR TITLE
Homepage navbar to display only on 2 rows on small screens

### DIFF
--- a/app/assets/stylesheets/ubiquity.scss
+++ b/app/assets/stylesheets/ubiquity.scss
@@ -15,3 +15,11 @@ th > span .attribute-label, .h4 {
 .image-masthead .background-container-gradient {
   background: none;
 }
+
+.nav, .navbar-nav, .homepage-nav-ul {
+  margin: 0px;
+}
+
+.nav, .navbar-nav > li > a {
+  padding: 8px 5px 7px 0px;
+}

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,0 +1,22 @@
+<!-- From hyrax/app/views/_controls.html.erb -->
+<nav class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="row col-sm-5 col-md-6">
+        <ul class="nav navbar-nav homepage-nav-ul">
+          <li class="col-xs-2 col-sm-3 col-md-3" <%= 'class=active' if current_page?(hyrax.root_path) %>>
+            <%= link_to t(:'hyrax.controls.home'), hyrax.root_path %></li>
+          <li class="col-xs-2 col-sm-3 col-md-3" <%= 'class=active' if current_page?(hyrax.about_path) %>>
+            <%= link_to t(:'hyrax.controls.about'), hyrax.about_path %></li>
+          <li class="col-xs-2 col-sm-3 col-md-3" <%= 'class=active' if current_page?(hyrax.help_path) %>>
+            <%= link_to t(:'hyrax.controls.help'), hyrax.help_path %></li>
+          <li class="col-xs-2 col-sm-3 col-md-3" <%= 'class=active' if current_page?(hyrax.contact_path) %>>
+            <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path %></li>
+        </ul>
+      </div>
+      <div class="searchbar-right navbar-right col-sm-7 col-md-6">
+        <%= render partial: 'catalog/search_form' %>
+      </div>
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
Trello #[248](https://trello.com/c/jnSXj9Tx)

On small screens, navbar to look like this:
![screenshot from 2018-10-03 14-47-20](https://user-images.githubusercontent.com/26539307/46416145-d74e9d80-c71e-11e8-9a07-c18e19b48ddc.png)

Instead of this:
![small-screen](https://user-images.githubusercontent.com/26539307/46416196-f6e5c600-c71e-11e8-8200-2376706a04b3.png)

