### PR TITLE
Separate multiple URLs with a <br/>

### DIFF
--- a/app/renderers/hyrax/renderers/external_url_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/external_url_attribute_renderer.rb
@@ -4,8 +4,7 @@ class ExternalUrlAttributeRenderer < Hyrax::Renderers::AttributeRenderer
     markup = ''
     values.delete("") if values # delete an empty string in array or it would display
     return markup if values.blank? && !options[:include_empty]
-    return arr_of_li_values(values) if values.is_a?(Array)
-    Rails.logger.info("ExternalUrlAttributeRenderer did not render #{values}")
+    arr_of_li_values(values) if values.is_a?(Array)
   end
 
   private

--- a/app/renderers/hyrax/renderers/external_url_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/external_url_attribute_renderer.rb
@@ -1,20 +1,25 @@
 class ExternalUrlAttributeRenderer < Hyrax::Renderers::AttributeRenderer
+
   def render
     markup = ''
     values.delete("") if values # delete an empty string in array or it would display
     return markup if values.blank? && !options[:include_empty]
-    link = values.is_a?(Array) ? values.join : values
-    li_value(link)
+    return arr_of_li_values(values) if values.is_a?(Array)
+    Rails.logger.info("ExternalUrlAttributeRenderer did not render #{values}")
   end
 
   private
 
-  def li_value(value)
-    markup = %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
-    attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
-    markup << "<li#{html_attributes(attributes)}>"
-    markup << auto_link(value, html: { target: '_blank' })
-    markup << %(</li></ul></td></tr>)
-    markup.html_safe
-  end
+    def arr_of_li_values(value)
+      markup = %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
+      attributes = microdata_object_attributes(field).merge(class: "attribute attribute-#{field}")
+      markup << "<li#{html_attributes(attributes)}>"
+      links = value.map do |url|
+        auto_link(url, html: { target: '_blank' })
+      end
+      markup << links.join('<br/>')
+      markup << %(</li></ul></td></tr>)
+      markup.html_safe
+    end
+
 end


### PR DESCRIPTION
Fixes issue observed on testing site; Trello #[226](https://trello.com/c/qLL8hEl6):
"If more than one 'Related URL' is entered, they display as one and makes one long incorrect URL"

Follow up on #97 