### PR TITLE
Changes to creator/contributor/editor metadata fields

### DIFF
--- a/app/views/shared/ubiquity/contributor/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/contributor/_edit_array_hash_form.html.erb
@@ -2,86 +2,81 @@
 
 <% array_of_hash.each_with_index do |hash, index| %>
 
-<div class="ubiquity-meta-contributor" >
+  <div class="ubiquity-meta-contributor" >
 
-   <label class="control-label multi_value optional" for="#{template}_contributor_name_type">
-    Contributor name type</label>
-
+    <label class="control-label multi_value optional" for="#{template}_contributor_name_type">
+      Contributor name type</label>
     <%= select_tag "#{template}[contributor_group][][contributor_name_type]",
-       content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("contributor_name_type")), class: "ubiquity_contributor_name_type" %>
-  <br/>
-  <label class="control-label multi_value optional" for="#{template}_contributor_type">
-   Contributor type</label>
+        content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("contributor_name_type")), class: "ubiquity_contributor_name_type" %>
 
- <%= select_tag "#{template}[contributor_group][][contributor_type]",
-         content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( ContributorGroupService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("contributor_type"))
-  %>
+    <p class="help-block">A person or group you want to recognize for playing a role in the creation of the work, but not
+      the primary role.</p>
 
-  <br/>
-  <label class="control-label multi_value optional" for="#{template}_contributor_isni">
-    contributor ISNI</label>
+    <label class="control-label multi_value optional" for="#{template}_contributor_isni">
+      Contributor ISNI</label>
+    <%= text_field_tag "#{template}[contributor_group][][contributor_isni]", hash.dig("contributor_isni"),
+                       class: "#{template}_contributor_group form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the contributor\'s ISNI, e.g. 0000 1234 5678 9101.',
+                       name: "#{template}[contributor_group][][contributor_isni]"
+    %>
+    <br/>
+    <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="#{template}_contributor_organization_name">
+      Contributor organisation name</label>
+    <%= text_field_tag  "#{template}[contributor_group][][contributor_organization_name]", hash.dig("contributor_organization_name"),
+                        class: "ubiquity_contributor_organization_name #{template}_contributor_organization_name form-control multi-text-field multi_value",
+                        placeholder: 'Please enter the organisation\'s name.',
+                        name: "#{template}[contributor_group][][contributor_organization_name]"
+    %>
 
-  <%= text_field_tag "#{template}[contributor_group][][contributor_isni]", hash.dig("contributor_isni"),
-                     class: "#{template}_contributor_group form-control multi-text-field multi_value",
-                     name: "#{template}[contributor_group][][contributor_isni]"
-  %>
-  <br/>
-  <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="#{template}_contributor_organization_name">
-    Contributor organization name</label>
+    <span class="ubiquity_personal_fields">
 
-  <%= text_field_tag  "#{template}[contributor_group][][contributor_organization_name]", hash.dig("contributor_organization_name"),
-                      class: "ubiquity_contributor_organization_name #{template}_contributor_organization_name form-control multi-text-field multi_value",
-                      placeholder: 'Add contributor organization name',
-                      name: "#{template}[contributor_group][][contributor_organization_name]"
-  %>
-  </br>
+      <label class="control-label multi_value optional" for="#{template}_contributor_orcid">
+        Contributor ORCiD</label>
+      <%= text_field_tag "#{template}[contributor_group][][contributor_orcid]", hash.dig("contributor_orcid"),
+                         class: "#{template}_contributor_group form-control multi-text-field multi_value",
+                         placeholder: 'Please enter the contributor\'s ORCiD, e.g. 0000-1234-5678-9101.',
+                         name: "#{template}[contributor_group][][contributor_orcid]"
+      %>
+      <br>
 
-<span class="ubiquity_personal_fields">
       <label class="control-label multi_value optional" for="#{template}_contributor_given_name">
         Contributor given name</label>
-
       <%= text_field_tag "#{template}[contributor_group][][contributor_given_name]", hash.dig("contributor_given_name"),
                          class: "#{template}_contributor_group form-control multi-text-field multi_value",
+                         placeholder: 'Please enter the contributor\'s first name/given name.',
                          name: "#{template}[contributor_group][][contributor_given_name]"
       %>
-
       <br>
+
       <label class="control-label multi_value optional" for="#{template}_contributor_family">
         Contributor family name</label>
-
-
       <%= text_field_tag "#{template}[contributor_group][][contributor_family_name]", hash.dig("contributor_family_name"),
                          class: "#{template}_contributor_group form-control multi-text-field multi_value",
+                         placeholder: 'Please enter the contributor\'s last name/family name.',
                          name: "#{template}[contributor_group][][contributor_family_name]"
 
       %>
 
-      <br/>
+    </span>
+    <br>
+    <label class="control-label multi_value optional" for="#{template}_contributor_type">
+      Contributor type</label>
+    <%= select_tag "#{template}[contributor_group][][contributor_type]",
+                   content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( ContributorGroupService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("contributor_type"))
+    %>
+    <br><br/>
 
-      <label class="control-label multi_value optional" for="#{template}_contributor_orcid">
-        contributor ORCiD</label>
+    <%= hidden_field_tag "#{template}[contributor_group][][contributor_position]", index, class: 'ubiquity-contributor-score'  %>
 
-      <%= text_field_tag "#{template}[contributor_group][][contributor_orcid]", hash.dig("contributor_orcid"),
-                         class: "#{template}_contributor_group form-control multi-text-field multi_value",
-                         name: "#{template}[contributor_group][][contributor_orcid]"
-      %>
-  </span>
-      <br/>
+    <a href="#" style="color:red;"  class=" remove_contributor form-group " data-removeUbiquitycontributor=".ubiquity-meta-contributor">
+      <span class="glyphicon glyphicon-remove"></span>
+      <span class="controls-remove-text">Remove</span>
+    </a>
+    |
+    <a href="#" class=" add_contributor" data-addUbiquitycontributor=".ubiquity-meta-contributor">Add another </a>
 
+    <br><br><br/>
 
-      <%= hidden_field_tag "#{template}[contributor_group][][contributor_position]", index, class: 'ubiquity-contributor-score'  %>
-
-      <br/>
-      <a href="#" style="color:red;"  class=" remove_contributor form-group " data-removeUbiquitycontributor=".ubiquity-meta-contributor">
-        <span class="glyphicon glyphicon-remove"></span>
-        <span class="controls-remove-text">Remove</span>
-      </a>
-      |
-
-      <a href="#" class=" add_contributor" data-addUbiquitycontributor=".ubiquity-meta-contributor">Add another </a>
-
-      <br/>
-
-</div>
+  </div>
 
 <% end %>

--- a/app/views/shared/ubiquity/contributor/_new_form.html.erb
+++ b/app/views/shared/ubiquity/contributor/_new_form.html.erb
@@ -4,84 +4,81 @@
 <div class="ubiquity-meta-contributor" >
   
   <label class="control-label multi_value optional" for="#{template}_contributor_name_type">
-    contributor name type</label>
+    Contributor name type</label>
 
   <%= select_tag "#{template}[contributor_group][][contributor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s), class: "ubiquity_contributor_name_type" %>
 
-  <br/>
+  <p class="help-block">A person or group you want to recognize for playing a role in the creation of the work, but not the primary role.</p>
+
   <label class="control-label multi_value optional" for="#{template}_contributor_isni">
     Contributor ISNI</label>
 
   <%= text_field_tag "#{template}[contributor_group][][contributor_isni]", nil,
                      class: "#{template}_contributor_group form-control multi-text-field multi_value",
-                     placeholder: 'Add contributor isni',
+                     placeholder: 'Please enter the contributor\'s ISNI, e.g. 0000 1234 5678 9101.',
                      name: "#{template}[contributor_group][][contributor_isni]"
   %>
 
   <br/>
 
-    <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="#{template}_contributor_organization_name">
-      Contributor organization name</label>
+  <label class="ubiquity_contributor_organization_name control-label multi_value optional" for="#{template}_contributor_organization_name">
+    Contributor organisation name</label>
 
-    <%= text_field_tag  "#{template}[contributor_group][][contributor_organization_name]", nil,
-                        class: "ubiquity_contributor_organization_name #{template}_contributor_organization_name form-control multi-text-field multi_value",
-                        placeholder: 'Add contributor organization name',
-                        name: "#{template}[contributor_group][][contributor_organization_name]"
+  <%= text_field_tag "#{template}[contributor_group][][contributor_organization_name]", nil,
+                     class: "ubiquity_contributor_organization_name #{template}_contributor_organization_name form-control multi-text-field multi_value",
+                     placeholder: 'Please enter the organisation\'s name.',
+                     name: "#{template}[contributor_group][][contributor_organization_name]"
+  %>
+
+  <span class="ubiquity_personal_fields">
+
+    <label class="control-label multi_value optional" for="#{template}_contributor_orcid">
+      Contributor ORCiD</label>
+
+    <%= text_field_tag "#{template}[contributor_group][][contributor_orcid]", nil,
+                       class: "#{template}_contributor_group form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the contributor\'s ORCiD, e.g. 0000-1234-5678-9101.',
+                       name: "#{template}[contributor_group][][contributor_orcid]"
     %>
-    </br>
- <span class="ubiquity_personal_fields">
+    <br>
+
+    <label class="control-label multi_value optional" for="#{template}_contributor_family_name">
+      Contributor family name</label>
+
+    <%= text_field_tag "#{template}[contributor_group][][contributor_family_name]", nil,
+                       class: "#{template}_contributor_family_name form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the contributor\'s last name/family name.',
+                       name: "#{template}[contributor_group][][contributor_family_name]"
+    %>
+    <br>
+
+    <label class="control-label multi_value optional" for="#{template}_contributor_given_name">
+      Contributor given name</label>
+
+    <%= text_field_tag "#{template}[contributor_group][][contributor_given_name]", nil,
+                       class: "#{template}_contributor_given_name form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the contributor\'s first name/given name.',
+                       name: "#{template}[contributor_group][][contributor_given_name]"
+    %>
+
+  </span>
+  <br>
   <label class="control-label multi_value optional" for="#{template}_contributor_type">
-   Contributor type</label>
-
- <%= select_tag "#{template}[contributor_group][][contributor_type]",
-         content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( ContributorGroupService.new.select_active_options.flatten.uniq!, :to_s, :to_s)
+    Contributor type</label>
+  <%= select_tag "#{template}[contributor_group][][contributor_type]",
+                 content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( ContributorGroupService.new.select_active_options.flatten.uniq!, :to_s, :to_s)
   %>
+  <br><br/>
 
-  <br/>
-
-  <label class="control-label multi_value optional" for="#{template}_contributor_given_name">
-    Contributor given name</label>
-
-  <%= text_field_tag  "#{template}[contributor_group][][contributor_given_name]", nil,
-                      class: "#{template}_contributor_given_name form-control multi-text-field multi_value",
-                      placeholder: 'Add contributor given name',
-                      name: "#{template}[contributor_group][][contributor_given_name]"
-  %>
-
-  <br>
-  <label class="control-label multi_value optional" for="#{template}_contributor_family_name">
-    Contributor family name</label>
-
-  <%= text_field_tag  "#{template}[contributor_group][][contributor_family_name]", nil,
-                      class: "#{template}_contributor_family_name form-control multi-text-field multi_value",
-                      placeholder: 'Add contributor family name',
-                      name: "#{template}[contributor_group][][contributor_family_name]"
-  %>
-
-  <br>
-  <label class="control-label multi_value optional" for="#{template}_contributor_orcid">
-    Contributor ORCiD</label>
-
-  <%= text_field_tag "#{template}[contributor_group][][contributor_orcid]", nil,
-                     class: "#{template}_contributor_group form-control multi-text-field multi_value",
-                     placeholder: 'Add contributor orcid',
-                     name: "#{template}[contributor_group][][contributor_orcid]"
-  %>
-
-</span>
-  <br/>
-
-    <%= hidden_field_tag "#{template}[contributor_group][][contributor_position]", 1, class: 'ubiquity-contributor-score'  %>
-   <br/>
+  <%= hidden_field_tag "#{template}[contributor_group][][contributor_position]", 1, class: 'ubiquity-contributor-score'  %>
 
   <a href="#" style="color:red;"  class=" remove_contributor form-group " data-removeUbiquitycontributor=".ubiquity-meta-contributor">
     <span class="glyphicon glyphicon-remove"></span>
     <span class="controls-remove-text">Remove</span>
   </a>
   |
-
   <a href="#" class=" add_contributor" data-addUbiquitycontributor=".ubiquity-meta-contributor">Add another </a>
 
-  <br> <br>
+  <br><br><br/>
 
 </div>

--- a/app/views/shared/ubiquity/creator/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/creator/_edit_array_hash_form.html.erb
@@ -5,83 +5,86 @@
 
 <div class="ubiquity-meta-creator" >
   <% if template == 'collection' %>
-   <label class="control-label multi_value optional" for="#{template}_creator_name_type">
-    Creator name type</label>
+    <label class="control-label multi_value optional" for="#{template}_creator_name_type">
+      Creator name type</label>
 
     <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("creator_name_type")),
-         class:  'ubiquity_creator_name_type' %>
+                    class: 'ubiquity_creator_name_type' %>
 
   <% else %>
     <label class="control-label multi_value optional" for="#{template}_creator_name_type">
-     Creator name type <span class="label label-info required-tag">required</span></label>
+      Creator name type <span class="label label-info required-tag">required</span></label>
 
-     <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("creator_name_type")),
-       required: true, class:  'ubiquity_creator_name_type' %>
+    <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("creator_name_type")),
+                   required: true, class: 'ubiquity_creator_name_type' %>
   <% end %>
 
-    <br/>
-    <label class="ubiquity_creator_isni control-label multi_value optional" for="#{template}_creator_isni">
-      Creator ISNI</label>
+  <p class="help-block">The person or group responsible for the work. Usually this is the author of the content.</p>
 
-    <%= text_field_tag "#{template}[creator_group][][creator_isni]", hash.dig("creator_isni"),
-                     class: "ubiquity_creator_isni #{template}_creator_group form-control multi-text-field multi_value",
-                     name: "#{template}[creator_group][][creator_isni]"
-    %>
-    <br/>
-    <label class="ubiquity_creator_organization_name control-label multi_value optional" for="#{template}_creator_organization_name">
-      Creator organization name</label>
+  <label class="ubiquity_creator_isni control-label multi_value optional" for="#{template}_creator_isni">
+    Creator ISNI</label>
 
-    <%= text_field_tag  "#{template}[creator_group][][creator_organization_name]", hash.dig("creator_organization_name"),
+  <%= text_field_tag "#{template}[creator_group][][creator_isni]", hash.dig("creator_isni"),
+                      class: "ubiquity_creator_isni #{template}_creator_group form-control multi-text-field multi_value",
+                      placeholder: 'Please enter the creator\'s ISNI, e.g. 0000 1234 5678 9101.',
+                      name: "#{template}[creator_group][][creator_isni]"
+  %>
+  <br/>
+  <label class="ubiquity_creator_organization_name control-label multi_value optional" for="#{template}_creator_organization_name">
+    Creator organisation name</label>
+
+  <%= text_field_tag "#{template}[creator_group][][creator_organization_name]", hash.dig("creator_organization_name"),
                       class: "ubiquity_creator_organization_name #{template}_creator_organization_name form-control multi-text-field multi_value",
-                      placeholder: 'Add creator organization name',
+                      placeholder: 'Please enter the organisation\'s name.',
                       name: "#{template}[creator_group][][creator_organization_name]"
+  %>
+
+  <span class="ubiquity_personal_fields">
+
+    <label class="ubiquity_creator_orcid control-label multi_value optional" for="#{template}_creator_orcid">
+      Creator ORCiD</label>
+
+    <%= text_field_tag "#{template}[creator_group][][creator_orcid]", hash.dig("creator_orcid"),
+                       class: "ubiquity_creator_orcid #{template}_creator_group form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the creator\'s ORCiD, e.g. 0000-1234-5678-9101.',
+                       name: "#{template}[creator_group][][creator_orcid]"
     %>
-    <br/>
-    <span class="ubiquity_personal_fields">
-      <label class="ubiquity_creator_given_name control-label multi_value optional" for="#{template}_creator_given_name">
-        Creator given name  </label>
+    <br>
 
-      <%= text_field_tag "#{template}[creator_group][][creator_given_name]", hash.dig("creator_given_name"),
-                         class: "ubiquity_creator_given_name #{template}_creator_group form-control multi-text-field multi_value",
-                         name: "#{template}[creator_group][][creator_given_name]"
+    <label class="ubiquity_creator_family_name control-label multi_value optional" for="#{template}_creator_family">
+      Creator family name</label>
 
-      %>
+    <%= text_field_tag "#{template}[creator_group][][creator_family_name]", hash.dig("creator_family_name"),
+                       class: "ubiquity_creator_family_name #{template}_creator_group form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the creator\'s last name/family name.',
+                       name: "#{template}[creator_group][][creator_family_name]"
 
-      <br>
-      <label class="ubiquity_creator_family_name control-label multi_value optional" for="#{template}_creator_family">
-        Creator family name</label>
+    %>
+    <br>
 
+    <label class="ubiquity_creator_given_name control-label multi_value optional" for="#{template}_creator_given_name">
+      Creator given name  </label>
 
-      <%= text_field_tag "#{template}[creator_group][][creator_family_name]", hash.dig("creator_family_name"),
-                         class: "ubiquity_creator_family_name #{template}_creator_group form-control multi-text-field multi_value",
-                         name: "#{template}[creator_group][][creator_family_name]"
+    <%= text_field_tag "#{template}[creator_group][][creator_given_name]", hash.dig("creator_given_name"),
+                       class: "ubiquity_creator_given_name #{template}_creator_group form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the creator\'s first name/given name.',
+                       name: "#{template}[creator_group][][creator_given_name]"
 
-      %>
+    %>
 
-      <br>
+  </span>
+  <br>
 
-      <label class="ubiquity_creator_orcid control-label multi_value optional" for="#{template}_creator_orcid">
-        Creator ORCiD</label>
+  <%= hidden_field_tag "#{template}[creator_group][][creator_position]", index, class: 'ubiquity-creator-score'  %>
 
-      <%= text_field_tag "#{template}[creator_group][][creator_orcid]", hash.dig("creator_orcid"),
-                         class: "ubiquity_creator_orcid #{template}_creator_group form-control multi-text-field multi_value",
-                         name: "#{template}[creator_group][][creator_orcid]"
-      %>
-    </span>
-      <br>
+  <a href="#" style="color:red;"  class=" remove_creator form-group " data-removeUbiquityCreator=".ubiquity-meta-creator">
+    <span class="glyphicon glyphicon-remove"></span>
+    <span class="controls-remove-text">Remove</span>
+  </a>
+  |
+  <a href="#" class=" add_creator" data-addUbiquityCreator=".ubiquity-meta-creator">Add another </a>
 
-      <%= hidden_field_tag "#{template}[creator_group][][creator_position]", index, class: 'ubiquity-creator-score'  %>
-
-      <br>
-      <a href="#" style="color:red;"  class=" remove_creator form-group " data-removeUbiquityCreator=".ubiquity-meta-creator">
-        <span class="glyphicon glyphicon-remove"></span>
-        <span class="controls-remove-text">Remove</span>
-      </a>
-      |
-
-      <a href="#" class=" add_creator" data-addUbiquityCreator=".ubiquity-meta-creator">Add another </a>
-
-      <br> <br>
+  <br><br><br>
 
 </div>
 

--- a/app/views/shared/ubiquity/creator/_new_form.html.erb
+++ b/app/views/shared/ubiquity/creator/_new_form.html.erb
@@ -3,82 +3,80 @@
 
 <div class="ubiquity-meta-creator" >
   <% if template == 'collection' %>
-      <label class="control-label multi_value optional" for="#{template}_creator_name_type">
-       Creator name type</label>
+    <label class="control-label multi_value optional" for="#{template}_creator_name_type">
+      Creator name type</label>
 
-       <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
+    <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
         class: "ubiquity_creator_name_type"  %>
   <% else %>
-       <label class="control-label multi_value optional" for="#{template}_creator_name_type">
-          Creator name type <span class="label label-info required-tag">required</span></label>
+    <label class="control-label multi_value optional" for="#{template}_creator_name_type">
+      Creator name type <span class="label label-info required-tag">required</span></label>
 
-      <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
-         required: true, class: "ubiquity_creator_name_type"  %>
+    <%= select_tag "#{template}[creator_group][][creator_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s),
+        required: true, class: "ubiquity_creator_name_type"  %>
   <% end %>
-  <br>
+
+  <p class="help-block">The person or group responsible for the work. Usually this is the author of the content.</p>
+
   <label class="control-label multi_value optional" for="#{template}_creator_isni">
     Creator ISNI</label>
 
   <%= text_field_tag "#{template}[creator_group][][creator_isni]", nil,
                      class: "#{template}_creator_group form-control multi-text-field multi_value",
-                     placeholder: 'Add creator isni',
+                     placeholder: 'Please enter the creator\'s ISNI, e.g. 0000 1234 5678 9101.',
                      name: "#{template}[creator_group][][creator_isni]"
   %>
 
   <br/>
 
   <label class="ubiquity_creator_organization_name control-label multi_value optional" for="generic_work_creator_organization_name">
-    Creator organization name</label>
+    Creator organisation name</label>
 
   <%= text_field_tag  "#{template}[creator_group][][creator_organization_name]", nil,
                       class: "ubiquity_creator_organization_name generic_work_creator_organization_name form-control multi-text-field multi_value",
-                      placeholder: 'Add creator organization name',
+                      placeholder: 'Please enter the organisation\'s name.',
                       name: "#{template}[creator_group][][creator_organization_name]"
   %>
-  </br>
- <span class="ubiquity_personal_fields">
-  <label class="control-label multi_value optional" for="#{template}_creator_given_name">
-    Creator given name</label>
 
-  <%= text_field_tag  "#{template}[creator_group][][creator_given_name]", nil,
-                      class: "#{template}_creator_given_name form-control multi-text-field multi_value",
-                      placeholder: 'Add creator given name',
-                      name: "#{template}[creator_group][][creator_given_name]"
-  %>
+  <span class="ubiquity_personal_fields">
 
-  <br>
-  <label class="control-label multi_value optional" for="#{template}_creator_family_name">
-    Creator family name</label>
+    <label class="control-label multi_value optional" for="#{template}_creator_orcid">
+      Creator ORCiD</label>
+    <%= text_field_tag "#{template}[creator_group][][creator_orcid]", nil,
+                       class: "#{template}_creator_group form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the creator\'s ORCiD, e.g. 0000-1234-5678-9101.',
+                       name: "#{template}[creator_group][][creator_orcid]"
+    %>
+    <br>
 
-  <%= text_field_tag  "#{template}[creator_group][][creator_family_name]", nil,
-                      class: "#{template}_creator_family_name form-control multi-text-field multi_value",
-                      placeholder: 'Add creator family name',
-                      name: "#{template}[creator_group][][creator_family_name]"
-  %>
+    <label class="control-label multi_value optional" for="#{template}_creator_family_name">
+      Creator family name</label>
+    <%= text_field_tag  "#{template}[creator_group][][creator_family_name]", nil,
+                        class: "#{template}_creator_family_name form-control multi-text-field multi_value",
+                        placeholder: 'Please enter the creator\'s last name/family name.',
+                        name: "#{template}[creator_group][][creator_family_name]"
+    %>
+    <br>
 
-  <br>
-  <label class="control-label multi_value optional" for="#{template}_creator_orcid">
-    Creator ORCiD</label>
-
-  <%= text_field_tag "#{template}[creator_group][][creator_orcid]", nil,
-                     class: "#{template}_creator_group form-control multi-text-field multi_value",
-                     placeholder: 'Add creator orcid',
-                     name: "#{template}[creator_group][][creator_orcid]"
-  %>
+    <label class="control-label multi_value optional" for="#{template}_creator_given_name">
+      Creator given name</label>
+    <%= text_field_tag  "#{template}[creator_group][][creator_given_name]", nil,
+                        class: "#{template}_creator_given_name form-control multi-text-field multi_value",
+                        placeholder: 'Please enter the creator\'s first name/given name.',
+                        name: "#{template}[creator_group][][creator_given_name]"
+    %>
 
   </span>
   <br>
-    <%= hidden_field_tag "#{template}[creator_group][][creator_position]", 1, class: 'ubiquity-creator-score'  %>
-   <br>
+  <%= hidden_field_tag "#{template}[creator_group][][creator_position]", 1, class: 'ubiquity-creator-score'  %>
 
   <a href="#" style="color:red;"  class=" remove_creator form-group " data-removeUbiquitycreator=".ubiquity-meta-creator">
     <span class="glyphicon glyphicon-remove"></span>
     <span class="controls-remove-text">Remove</span>
   </a>
   |
-
   <a href="#" class=" add_creator" data-addUbiquitycreator=".ubiquity-meta-creator">Add another </a>
 
-  <br> <br>
+  <br><br><br>
 
 </div>

--- a/app/views/shared/ubiquity/editor/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/editor/_edit_array_hash_form.html.erb
@@ -1,82 +1,78 @@
 <% template = curation_concern.class.to_s.underscore %>
 
-
 <% array_of_hash.each_with_index do |hash, index| %>
 
-<div class="ubiquity-meta-editor" >
+  <div class="ubiquity-meta-editor" >
 
-   <label class="control-label multi_value optional" for="#{template}_editor_name_type">
-    Editor name type</label>
+    <label class="control-label multi_value optional" for="#{template}_editor_name_type">
+      Editor name type</label>
+    <%= select_tag "#{template}[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("editor_name_type")),
+                   class:  'ubiquity_editor_name_type' %>
+    <br/>
 
-    <%= select_tag "#{template}[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("editor_name_type")), class:  'ubiquity_editor_name_type' %>
+    <p class="help-block">The editors that produced this item, in priority order. To add multiple editors, repeat this property.</p>
 
-  <br/>
-  <label class="control-label multi_value optional" for="#{template}_editor_isni">
-    Editor ISNI</label>
+    <label class="control-label multi_value optional" for="#{template}_editor_isni">
+      Editor ISNI</label>
+    <%= text_field_tag "#{template}[editor_group][][editor_isni]", hash.dig("editor_isni"),
+                       class: "#{template}_editor_group form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the editor\'s ISNI, e.g. 0000 1234 5678 9101.',
+                       name: "#{template}[editor_group][][editor_isni]"
+    %>
+    <br>
 
-  <%= text_field_tag "#{template}[editor_group][][editor_isni]", hash.dig("editor_isni"),
-                     class: "#{template}_editor_group form-control multi-text-field multi_value",
-                     name: "#{template}[editor_group][][editor_isni]"
-  %>
-  <br>
-  <br/>
-  <label class="ubiquity_editor_organization_name control-label multi_value optional" for="#{template}_editor_organization_name">
-    Editor organization name</label>
+    <label class="ubiquity_editor_organization_name control-label multi_value optional" for="#{template}_editor_organization_name">
+      Editor organisation name</label>
+    <%= text_field_tag  "#{template}[editor_group][][editor_organization_name]", hash.dig("editor_organization_name"),
+                        class: "ubiquity_editor_organization_name #{template}_editor_organization_name form-control multi-text-field multi_value",
+                        placeholder: 'Please enter the organisation\'s name.',
+                        name: "#{template}[editor_group][][editor_organization_name]"
+    %>
 
-  <%= text_field_tag  "#{template}[editor_group][][editor_organization_name]", hash.dig("editor_organization_name"),
-                      class: "ubiquity_editor_organization_name #{template}_editor_organization_name form-control multi-text-field multi_value",
-                      placeholder: 'Add editor organization name',
-                      name: "#{template}[editor_group][][editor_organization_name]"
-  %>
-  <br/>
-  <span class="ubiquity_personal_fields">
+    <span class="ubiquity_personal_fields">
+
+      <label class="control-label multi_value optional" for="#{template}_editor_orcid">
+        Editor ORCiD</label>
+      <%= text_field_tag "#{template}[editor_group][][editor_orcid]", hash.dig("editor_orcid"),
+                         class: "#{template}_editor_group form-control multi-text-field multi_value",
+                         placeholder: 'Please enter the editor\'s ORCiD, e.g. 0000-1234-5678-9101.',
+                         name: "#{template}[editor_group][][editor_orcid]"
+      %>
+      <br>
+
+      <label class="control-label multi_value optional" for="#{template}_editor_family">
+        Editor family name</label>
+      <%= text_field_tag "#{template}[editor_group][][editor_family_name]", hash.dig("editor_family_name"),
+                         class: "#{template}_editor_group form-control multi-text-field multi_value",
+                         placeholder: 'Please enter the editor\'s last name/family name.',
+                         name: "#{template}[editor_group][][editor_family_name]"
+
+      %>
+      <br>
+
       <label class="control-label multi_value optional" for="#{template}_editor_given_name">
         Editor given name  </label>
-
       <%= text_field_tag "#{template}[editor_group][][editor_given_name]", hash.dig("editor_given_name"),
                          class: "#{template}_editor_group form-control multi-text-field multi_value",
+                         placeholder: 'Please enter the editor\'s first name/given name.',
                          name: "#{template}[editor_group][][editor_given_name]"
 
       %>
 
-      <br>
-      <label class="control-label multi_value optional" for="#{template}_editor_family">
-        Editor family name</label>
+    </span>
 
+    <%= hidden_field_tag "#{template}[editor_group][][editor_position]", index, class: 'ubiquity-editor-score'  %>
 
-      <%= text_field_tag "#{template}[editor_group][][editor_family_name]", hash.dig("editor_family_name"),
-                         class: "#{template}_editor_group form-control multi-text-field multi_value",
-                         name: "#{template}[editor_group][][editor_family_name]"
+    <br/>
+    <a href="#" style="color:red;"  class=" remove_editor form-group " data-removeUbiquityEditor=".ubiquity-meta-editor">
+      <span class="glyphicon glyphicon-remove"></span>
+      <span class="controls-remove-text">Remove</span>
+    </a>
+    |
+    <a href="#" class=" add_editor" data-addUbiquityEditor=".ubiquity-meta-editor">Add another </a>
 
-      %>
+    <br><br><br>
 
-      <br>
-
-      <label class="control-label multi_value optional" for="#{template}_editor_orcid">
-        Editor ORCiD</label>
-
-      <%= text_field_tag "#{template}[editor_group][][editor_orcid]", hash.dig("editor_orcid"),
-                         class: "#{template}_editor_group form-control multi-text-field multi_value",
-                         name: "#{template}[editor_group][][editor_orcid]"
-      %>
-
-  </span>
-      <br/>
-
-
-      <%= hidden_field_tag "#{template}[editor_group][][editor_position]", index, class: 'ubiquity-editor-score'  %>
-
-      <br/>
-      <a href="#" style="color:red;"  class=" remove_editor form-group " data-removeUbiquityEditor=".ubiquity-meta-editor">
-        <span class="glyphicon glyphicon-remove"></span>
-        <span class="controls-remove-text">Remove</span>
-      </a>
-      |
-
-      <a href="#" class=" add_editor" data-addUbiquityEditor=".ubiquity-meta-editor">Add another </a>
-
-      <br> <br>
-
-</div>
+  </div>
 
 <% end %>

--- a/app/views/shared/ubiquity/editor/_new_form.html.erb
+++ b/app/views/shared/ubiquity/editor/_new_form.html.erb
@@ -7,67 +7,66 @@
 
   <%= select_tag "#{template}[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s), class:  'ubiquity_editor_name_type' %>
 
-  <br/>
+  <p class="help-block">The editors that produced this item, in priority order. To add multiple editors, repeat this property.</p>
+
   <label class="control-label multi_value optional" for="#{template}_editor_isni">
     Editor ISNI</label>
 
   <%= text_field_tag "#{template}[editor_group][][editor_isni]", nil,
                      class: "#{template}_editor_group form-control multi-text-field multi_value",
-                     placeholder: 'Add editor isni',
+                     placeholder: 'Please enter the editor\'s ISNI, e.g. 0000 1234 5678 9101.',
                      name: "#{template}[editor_group][][editor_isni]"
   %>
   <br/>
   <label class="ubiquity_editor_organization_name control-label multi_value optional" for="#{template}_editor_organization_name">
-    Editor organization name</label>
+    Editor organisation name</label>
 
   <%= text_field_tag  "#{template}[editor_group][][editor_organization_name]", nil,
                       class: "ubiquity_editor_organization_name #{template}_editor_organization_name form-control multi-text-field multi_value",
-                      placeholder: 'Add editor organization name',
+                      placeholder: 'Please enter the organisation\'s name.',
                       name: "#{template}[editor_group][][editor_organization_name]"
   %>
-  <br/>
+
   <span class="ubiquity_personal_fields">
-    <label class="control-label multi_value optional" for="#{template}_editor_given_name">
-    Editor given name</label>
 
-      <%= text_field_tag  "#{template}[editor_group][][editor_given_name]", nil,
-                      class: "#{template}_editor_given_name form-control multi-text-field multi_value",
-                      placeholder: 'Add editor given name',
-                      name: "#{template}[editor_group][][editor_given_name]"
-      %>
-
-     <br/>
-      <label class="control-label multi_value optional" for="#{template}_editor_family_name">
-    Editor family name</label>
-
-    <%= text_field_tag  "#{template}[editor_group][][editor_family_name]", nil,
-                      class: "#{template}_editor_family_name form-control multi-text-field multi_value",
-                      placeholder: 'Add editor family name',
-                      name: "#{template}[editor_group][][editor_family_name]"
-     %>
-
-   <br/>
     <label class="control-label multi_value optional" for="#{template}_editor_orcid">
-    Editor ORCiD</label>
+      Editor ORCiD</label>
+    <%= text_field_tag "#{template}[editor_group][][editor_orcid]", nil,
+                       class: "#{template}_editor_group form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the editor\'s ORCiD, e.g. 0000-1234-5678-9101.',
+                       name: "#{template}[editor_group][][editor_orcid]"
+    %>
+    <br>
 
-     <%= text_field_tag "#{template}[editor_group][][editor_orcid]", nil,
-                     class: "#{template}_editor_group form-control multi-text-field multi_value",
-                     placeholder: 'Add editor orcid',
-                     name: "#{template}[editor_group][][editor_orcid]"
-      %>
-   </span>
-   <br/>
-    <%= hidden_field_tag "#{template}[editor_group][][editor_position]", 1, class: 'ubiquity-editor-score'  %>
-   <br/>
+    <label class="control-label multi_value optional" for="#{template}_editor_family_name">
+      Editor family name</label>
+    <%= text_field_tag  "#{template}[editor_group][][editor_family_name]", nil,
+                        class: "#{template}_editor_family_name form-control multi-text-field multi_value",
+                        placeholder: 'Please enter the editor\'s last name/family name.',
+                        name: "#{template}[editor_group][][editor_family_name]"
+     %>
+    <br/>
+
+    <label class="control-label multi_value optional" for="#{template}_editor_given_name">
+      Editor given name</label>
+    <%= text_field_tag "#{template}[editor_group][][editor_given_name]", nil,
+                       class: "#{template}_editor_given_name form-control multi-text-field multi_value",
+                       placeholder: 'Please enter the editor\'s first name/given name.',
+                       name: "#{template}[editor_group][][editor_given_name]"
+    %>
+
+  </span>
+
+  <%= hidden_field_tag "#{template}[editor_group][][editor_position]", 1, class: 'ubiquity-editor-score'  %>
+  <br/>
 
   <a href="#" style="color:red;"  class=" remove_editor form-group " data-removeUbiquityEditor=".ubiquity-meta-editor">
     <span class="glyphicon glyphicon-remove"></span>
     <span class="controls-remove-text">Remove</span>
   </a>
   |
-
   <a href="#" class=" add_editor" data-addUbiquityEditor=".ubiquity-meta-editor">Add another </a>
 
-  <br> <br>
+  <br><br><br>
 
 </div>


### PR DESCRIPTION
Trello cards: #[195](https://trello.com/c/A4ZkGgna), #[202](https://trello.com/c/uief4f1M), #[224](https://trello.com/c/8swpoPQF)

Changes to Creator / Contributor / Editor form fields: 
- help text,
- UK spelling of 'organisation';
- reordering of sub-fields.
