### PR TITLE
preselecting contributor_name_type and editor_name_type now renders the right html form fields

### DIFF
--- a/app/views/shared/ubiquity/_editor_js.html.erb
+++ b/app/views/shared/ubiquity/_editor_js.html.erb
@@ -81,4 +81,22 @@
      };
    });
 
+   $(document).on("turbolinks:load", function(){
+     $("body").on("click",".additional-fields", function(event){
+       $(".ubiquity_editor_name_type").each(function() {
+         _this = this;
+         if (this.value == 'Personal') {
+           $(this).siblings(".ubiquity_editor_organization_name").hide();
+           $(this).siblings(".ubiquity_personal_fields").show();
+         } else if(this.value == "Organisational") {
+          $(this).siblings(".ubiquity_personal_fields").hide();
+          $(this).siblings(".ubiquity_editor_organization_name").show();
+        } else {
+          $('.ubiquity_editor_name_type:last').val('Personal').change()
+        }
+       });
+
+    });
+   });
+
 </script>

--- a/app/views/shared/ubiquity/contributor/_contributor_js.html.erb
+++ b/app/views/shared/ubiquity/contributor/_contributor_js.html.erb
@@ -81,4 +81,22 @@
       };
     });
 
+    $(document).on("turbolinks:load", function(){
+      $("body").on("click",".additional-fields", function(event){
+        $(".ubiquity_contributor_name_type").each(function() {
+          _this = this;
+          if (this.value == 'Personal') {
+            $(this).siblings(".ubiquity_contributor_organization_name").hide();
+            $(this).siblings(".ubiquity_personal_fields").show();
+          } else if(this.value == "Organisational") {
+           $(this).siblings(".ubiquity_personal_fields").hide();
+           $(this).siblings(".ubiquity_contributor_organization_name").show();
+         } else {
+           $('.ubiquity_contributor_name_type:last').val('Personal').change()
+         }
+        });
+
+     });
+    });
+
 </script>

--- a/app/views/shared/ubiquity/contributor/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/contributor/_edit_array_hash_form.html.erb
@@ -37,7 +37,7 @@
                          placeholder: 'Please enter the contributor\'s ORCiD, e.g. 0000-1234-5678-9101.',
                          name: "#{template}[contributor_group][][contributor_orcid]"
       %>
-      <br>
+      <br/>
 
       <label class="control-label multi_value optional" for="#{template}_contributor_given_name">
         Contributor given name</label>
@@ -46,7 +46,7 @@
                          placeholder: 'Please enter the contributor\'s first name/given name.',
                          name: "#{template}[contributor_group][][contributor_given_name]"
       %>
-      <br>
+      <br/>
 
       <label class="control-label multi_value optional" for="#{template}_contributor_family">
         Contributor family name</label>
@@ -58,13 +58,13 @@
       %>
 
     </span>
-    <br>
+    <br/>
     <label class="control-label multi_value optional" for="#{template}_contributor_type">
-      Contributor type</label>
+      Contributor type</label> 
     <%= select_tag "#{template}[contributor_group][][contributor_type]",
                    content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( ContributorGroupService.new.select_active_options.flatten.uniq!, :to_s, :to_s, hash.dig("contributor_type"))
     %>
-    <br><br/>
+    <br/><br/>
 
     <%= hidden_field_tag "#{template}[contributor_group][][contributor_position]", index, class: 'ubiquity-contributor-score'  %>
 
@@ -75,7 +75,7 @@
     |
     <a href="#" class=" add_contributor" data-addUbiquitycontributor=".ubiquity-meta-contributor">Add another </a>
 
-    <br><br><br/>
+    <br/><br/><br/>
 
   </div>
 

--- a/app/views/shared/ubiquity/contributor/_new_form.html.erb
+++ b/app/views/shared/ubiquity/contributor/_new_form.html.erb
@@ -2,11 +2,11 @@
 
 
 <div class="ubiquity-meta-contributor" >
-  
+
   <label class="control-label multi_value optional" for="#{template}_contributor_name_type">
     Contributor name type</label>
 
-  <%= select_tag "#{template}[contributor_group][][contributor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s), class: "ubiquity_contributor_name_type" %>
+  <%= select_tag "#{template}[contributor_group][][contributor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, 'Personal'), class: "ubiquity_contributor_name_type" %>
 
   <p class="help-block">A person or group you want to recognize for playing a role in the creation of the work, but not the primary role.</p>
 
@@ -40,7 +40,7 @@
                        placeholder: 'Please enter the contributor\'s ORCiD, e.g. 0000-1234-5678-9101.',
                        name: "#{template}[contributor_group][][contributor_orcid]"
     %>
-    <br>
+    <br/>
 
     <label class="control-label multi_value optional" for="#{template}_contributor_family_name">
       Contributor family name</label>
@@ -50,7 +50,7 @@
                        placeholder: 'Please enter the contributor\'s last name/family name.',
                        name: "#{template}[contributor_group][][contributor_family_name]"
     %>
-    <br>
+    <br/>
 
     <label class="control-label multi_value optional" for="#{template}_contributor_given_name">
       Contributor given name</label>
@@ -62,13 +62,13 @@
     %>
 
   </span>
-  <br>
+  <br/>
   <label class="control-label multi_value optional" for="#{template}_contributor_type">
     Contributor type</label>
   <%= select_tag "#{template}[contributor_group][][contributor_type]",
                  content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( ContributorGroupService.new.select_active_options.flatten.uniq!, :to_s, :to_s)
   %>
-  <br><br/>
+  <br/><br/>
 
   <%= hidden_field_tag "#{template}[contributor_group][][contributor_position]", 1, class: 'ubiquity-contributor-score'  %>
 
@@ -79,6 +79,6 @@
   |
   <a href="#" class=" add_contributor" data-addUbiquitycontributor=".ubiquity-meta-contributor">Add another </a>
 
-  <br><br><br/>
+  <br/><br/><br/>
 
 </div>

--- a/app/views/shared/ubiquity/editor/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/editor/_edit_array_hash_form.html.erb
@@ -19,7 +19,7 @@
                        placeholder: 'Please enter the editor\'s ISNI, e.g. 0000 1234 5678 9101.',
                        name: "#{template}[editor_group][][editor_isni]"
     %>
-    <br>
+    <br/>
 
     <label class="ubiquity_editor_organization_name control-label multi_value optional" for="#{template}_editor_organization_name">
       Editor organisation name</label>
@@ -38,7 +38,7 @@
                          placeholder: 'Please enter the editor\'s ORCiD, e.g. 0000-1234-5678-9101.',
                          name: "#{template}[editor_group][][editor_orcid]"
       %>
-      <br>
+      <br/>
 
       <label class="control-label multi_value optional" for="#{template}_editor_family">
         Editor family name</label>
@@ -48,7 +48,7 @@
                          name: "#{template}[editor_group][][editor_family_name]"
 
       %>
-      <br>
+      <br/>
 
       <label class="control-label multi_value optional" for="#{template}_editor_given_name">
         Editor given name  </label>
@@ -71,7 +71,7 @@
     |
     <a href="#" class=" add_editor" data-addUbiquityEditor=".ubiquity-meta-editor">Add another </a>
 
-    <br><br><br>
+    <br/><br/><br/>
 
   </div>
 

--- a/app/views/shared/ubiquity/editor/_new_form.html.erb
+++ b/app/views/shared/ubiquity/editor/_new_form.html.erb
@@ -5,7 +5,7 @@
   <label class="control-label multi_value optional" for="#{template}_editor_name_type">
     Editor name type</label>
 
-  <%= select_tag "#{template}[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s), class:  'ubiquity_editor_name_type' %>
+  <%= select_tag "#{template}[editor_group][][editor_name_type]", content_tag(:option,'select one...',:value=>"")+options_from_collection_for_select( NameTypeService.new.select_active_options.flatten.uniq!, :to_s, :to_s, "Personal"), class:  'ubiquity_editor_name_type' %>
 
   <p class="help-block">The editors that produced this item, in priority order. To add multiple editors, repeat this property.</p>
 
@@ -36,7 +36,7 @@
                        placeholder: 'Please enter the editor\'s ORCiD, e.g. 0000-1234-5678-9101.',
                        name: "#{template}[editor_group][][editor_orcid]"
     %>
-    <br>
+    <br/>
 
     <label class="control-label multi_value optional" for="#{template}_editor_family_name">
       Editor family name</label>


### PR DESCRIPTION
Addresses:
https://trello.com/c/YaWSaXia/245-01-on-submission-preselect-the-first-contributor-and-creator-name-type-fields-to-personal

https://trello.com/c/v2fdETCa/241-01-template-testing-contributor-type-field-disappears-if-contributor-name-type-organisational