### PR TITLE
Homepage content

### DIFF
--- a/app/assets/stylesheets/ubiquity.scss
+++ b/app/assets/stylesheets/ubiquity.scss
@@ -23,3 +23,32 @@ th > span .attribute-label, .h4 {
 .nav, .navbar-nav > li > a {
   padding: 8px 5px 7px 0px;
 }
+
+.mock-thumbnail {
+  height: 63px;
+  width: 50px;
+  padding-left: 105px;
+}
+
+.featured-fields {
+  margin-bottom: 15px;
+}
+
+.featured-item-thumbnail img {
+  padding: 1px;
+  border-radius: 2px;
+  border: 1px solid #bbb;
+  height: 180px;
+  margin-right: 15px;
+  margin-top: 3px;
+  object-fit: cover;
+  width: 100%;
+}
+
+.featured-item {
+  padding-top: 3px;
+}
+
+.homepage-field-title {
+  font-weight: 600;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -176,7 +176,7 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("project_name", :stored_searchable)
     config.add_show_field solr_name("official_link", :stored_searchable)
     config.add_show_field solr_name("rights_holder", :stored_searchable)
-    config.add_show_field solr_name("creator_search", :stored_searchable)
+    # config.add_show_field solr_name("creator_search", :stored_searchable)
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,4 +39,11 @@ module ApplicationHelper
       value
     end
   end
+
+  # For image thumbnails, override the default size for a better resolution on homepage
+  def render_related_img(solr_doc)
+    img_path = solr_doc['thumbnail_path_ss'].presence || ['/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png']
+    img_path = img_path.split('!150,300').join('600,') if img_path.include?('!150,300')
+    image_tag img_path
+  end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -56,3 +56,4 @@
 <% end %>
 <%#= presenter.attribute_to_html(:date_submitted) %>
 <%#= presenter.attribute_to_html(:refereed) %>
+<%= presenter.attribute_to_html(:creator_search) %>

--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -15,7 +15,7 @@
               <% end %>
             <% else %>
                <%= link_to "", class: 'media-left', 'aria-hidden' => true do %>
-                 <span class="media-left hidden-xs file_listing_thumbnail" style="height:55px;width:50px;padding-left: 105px;" ></span>
+                 <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>
                <% end %>
             <% end %>
             <div class="media-body">

--- a/app/views/hyrax/homepage/_featured.html.erb
+++ b/app/views/hyrax/homepage/_featured.html.erb
@@ -1,0 +1,6 @@
+<%# Override from Hyrax engine to remove `render_thumbnail_tag` and customise front-end %>
+
+<% presenter = featured.presenter %>
+<li class="featured-item" data-id="<%= presenter.id %>">
+  <%= render 'hyrax/homepage/featured_fields', featured: presenter %>
+</li>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -1,11 +1,12 @@
 <%# Override from Hyrax engine to customise front-end %>
 
 <% featured_doc = featured.solr_document %>
+
 <div class="featured-fields" >
-  <div class="featured-item-thumbnail" >
-    <%= render_thumbnail_tag(featured_doc, {suppress_link: true}) %>
-  </div>
   <%= link_to [main_app, featured] do %>
+    <div class="featured-item-thumbnail">
+      <%= render_related_img(featured_doc) %>
+    </div>
     <div class="featured-item homepage-field-title">
       <%= featured.title.first %>
     </div>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -1,0 +1,16 @@
+<%# Override from Hyrax engine to customise front-end %>
+
+<% featured_doc = featured.solr_document %>
+<div class="featured-fields" >
+  <div class="featured-item-thumbnail" >
+    <%= render_thumbnail_tag(featured_doc, {suppress_link: true}) %>
+  </div>
+  <%= link_to [main_app, featured] do %>
+    <div class="featured-item homepage-field-title">
+      <%= featured.title.first %>
+    </div>
+  <% end %>
+  <div class="featured-item">
+    <%= link_to_facet_list(featured_doc['creator_search_tesim'], 'creator_search').html_safe %>
+  </div>
+</div>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <div class="col-md-4 col-sm-4">
+    <h5 id="featured_works" class="nav-tabs"><%= t('hyrax.homepage.featured_works.tab_label') %></h5>
+    <%= render 'featured_works' %>
+  </div>
+  <div class="col-md-4 col-sm-4">
+    <h5 id="recent_works" class="nav-tabs"><%= t('hyrax.homepage.recently_uploaded.tab_label') %></h5>
+    <%= render 'recently_uploaded', recent_documents: @recent_documents %>
+  </div>
+  <div class="col-md-4 col-sm-4">
+    <h5 id="explore_collections" class="nav-tabs"><%= t('hyrax.homepage.admin_sets.title') %></h5>
+    <%= render 'explore_collections', collections: @presenter.collections %>
+  </div>
+</div>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,3 +1,5 @@
+<%# Override file from Hyrax engine to customise front-end %>
+
 <div class="row">
   <div class="col-md-4 col-sm-4">
     <h5 id="featured_works" class="nav-tabs"><%= t('hyrax.homepage.featured_works.tab_label') %></h5>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,23 +1,25 @@
 <%# Fix to not display default image icon. This file was copied from
   https://github.com/samvera/hyrax/blob/37a1c370cd05a7ed0a8ca2ad453bc15eb812f132/app/views/hyrax/homepage/_recent_document.html.erb
  %>
-
 <tr>
-    <td class="col-sm-2">
-      <%= link_to_profile recent_document.depositor("no depositor value") %>
+  <td>
+    <div class="media">
       <!-- if condition added by ubiquity to ensure default thumbnail is not displayed-->
-      <%if  recent_document.thumbnail_id %>
-        <%= link_to [main_app, recent_document] do %>
-          <%= render_thumbnail_tag recent_document, { width: 45 }, suppress_link: true %>
+      <% if recent_document.thumbnail_id %>
+        <%= link_to [main_app, recent_document], class: 'media-left', 'aria-hidden' => true do %>
+          <%= render_thumbnail_tag recent_document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+        <% end %>
+      <% else %>
+        <%= link_to "", class: 'media-left', 'aria-hidden' => true do %>
+          <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>
         <% end %>
       <% end %>
-    </td>
-    <td>
-      <h3>
-        <span class="sr-only">Title</span><%= link_to truncate(recent_document.to_s, length: 28, separator: ' '), [main_app, recent_document] %>
-      </h3>
-      <p>
-        <span class="sr-only">Keywords</span><%= link_to_facet_list(recent_document.keyword, 'keyword', 'no keywords specified').html_safe %>
-      </p>
-    </td>
-  </tr>
+      <div class="media-body">
+        <h5 class="homepage-field-title">
+          <span class="sr-only">Title</span><%= link_to (recent_document.to_s), [main_app, recent_document] %>
+        </h5>
+        <span class="sr-only">Creator</span><%= link_to_facet_list(recent_document.creator_search, 'creator_search').html_safe %>
+      </div>
+    </div>
+  </td>
+</tr>

--- a/app/views/hyrax/homepage/_recently_uploaded.html.erb
+++ b/app/views/hyrax/homepage/_recently_uploaded.html.erb
@@ -1,0 +1,14 @@
+<%# Overrides file from Hyrax engine to customise front-end %>
+
+<h2 class="sr-only"><%= t('hyrax.homepage.recently_uploaded.title') %></h2>
+<% if recent_documents.blank? %>
+  <p><%= t('.no_public') %></p>
+<% else %>
+  <div id="recent_docs">
+    <table class="table table-striped collection-highlights">
+      <tbody>
+        <%= render partial: "recent_document", collection: recent_documents %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/hyrax/homepage/_sortable_featured.html.erb
+++ b/app/views/hyrax/homepage/_sortable_featured.html.erb
@@ -1,0 +1,26 @@
+<%# Override hyrax/app/views/hyrax/homepage/_sortable_featured.html.erb %>
+<%# otherwise the version in Hyku v1.0.0.beta2 doubles the thumbnail: %>
+<%# here is the version currently in project: https://github.com/samvera/hyrax/blob/f02c648bb57c6fc32f16061ab1a487230ab3ee6a/app/views/hyrax/homepage/_sortable_featured.html.erb %>
+<%# code below is copied over from Hyrax v2.3.3 (no change) %>
+<% presenter = f.object.presenter %>
+<li class="dd-item dd3-item featured-item" data-id="<%= presenter.id %>">
+  <div class="dd-handle dd3-handle"><%= t 'hyrax.homepage.featured_works.drag' %></div>
+  <div class="dd3-content panel panel-default">
+    <%= f.hidden_field :id %>
+    <%= f.hidden_field :order, data: { property: "order" } %>
+    <div class="main row">
+      <div class="col-sm-12">
+        <% if can? :destroy, FeaturedWork %>
+          <h3 class="pull-right">
+            <%= link_to hyrax.featured_work_path(presenter, format: :json),
+                        title: "Remove work from feature section",
+                        data: {behavior: 'unfeature'} do %>
+              <i class='glyphicon glyphicon-remove'></i>
+            <% end %>
+          </h3>
+        <% end %>
+        <%= render 'hyrax/homepage/featured_fields', featured: presenter %>
+      </div>
+    </div>
+  </div>
+</li>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -10,6 +10,9 @@ en:
     footer:
       copyright_html: "<strong>Copyright &copy; 2017 Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
+    homepage:
+      recently_uploaded:
+        tab_label: Latest additions
   simple_form:
     hints:
       defaults:


### PR DESCRIPTION
As specified in Trello #[252](https://trello.com/c/wXDoUVmJ)

Homepage to look like:
![screenshot from 2018-10-12 16-03-37](https://user-images.githubusercontent.com/26539307/46877338-859dc580-ce38-11e8-9225-355f4757e28d.png)


Instead of:
![screenshot from 2018-10-12 16-03-59](https://user-images.githubusercontent.com/26539307/46877345-8c2c3d00-ce38-11e8-8f9c-17e4357960e0.png)


