### PR TITLE
stop empty contributor from saving

### DIFF
--- a/app/models/concerns/ubiquity/editor_metadata_model_concern.rb
+++ b/app/models/concerns/ubiquity/editor_metadata_model_concern.rb
@@ -26,9 +26,7 @@ module Ubiquity
       data = compare_hash_keys?(clean_submitted_data)
 
       if (self.editor_group.present? && clean_submitted_data.present? && !data )
-        # remove hash that contains only default keys and values.
-        new_editor_group = remove_hash_with_default_keys(clean_submitted_data)
-        editor_json = new_editor_group.to_json
+        editor_json =   clean_submitted_data.to_json
         self.editor = [editor_json]
       elsif  data
         #save an empty array since the sunmitted data contains only default keys & values


### PR DESCRIPTION
Resolve the issue of empty contributor still displaying as observed by Sara in this Trello card:

https://trello.com/c/0QcsuaJR/287-05-contributor-displays-in-front-end-even-when-empty-check-spec-re-test 

This can be reproduced in 2 ways:

1. Create a new work type but don't click the  'additional fields' button and then click save.

2. From an existing work, that is one that is already in the database but has no contributor, click edit, then save without clicking   'additional fields' button.

This is now fixed and pushed to Github.