### PR TITLE
Disable user sign-up

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,6 +60,6 @@ geonames_username: 'jcoyne'
 contact_email: ""
 
 devise:
-  account_signup: true
+  account_signup: false
   # The address from which user invitations are sent
   invitation_from_email: "change-me-in-hyku-settings@example.org"


### PR DESCRIPTION
Disable public account signup - signup by invitation from an admin user remains.
Trello #[304](https://trello.com/c/O9VVq2x3)