### PR TITLE
dont't iterate over nil

### DIFF
--- a/app/services/ubiquity/parse_json.rb
+++ b/app/services/ubiquity/parse_json.rb
@@ -7,12 +7,12 @@ module Ubiquity
     end
 
     def data
-      parsed_json = if @data.class == Array && @data.first.class == String
+      parsed_json = if @data.present? && @data.class == Array && @data.first.class == String
                       JSON.parse(@data.first)
                     elsif @data.class == String
                       JSON.parse(@data)
                     end
-      transform_data(parsed_json)
+      transform_data(parsed_json) if parsed_json.present?
     end
 
     def transform_data(parsed_json)
@@ -25,6 +25,7 @@ module Ubiquity
         value
       end
       value.reject(&:blank?).compact
+
     end
 
   end

--- a/app/views/shared/ubiquity/collections/_show_document_list_row.html.erb
+++ b/app/views/shared/ubiquity/collections/_show_document_list_row.html.erb
@@ -35,7 +35,7 @@
   <td>
     <div class="media-body">
       <%# UbiquityPress replaces document.creator.to_a.to_a pulled from document detail" %>
-      <span class="text-center"><%= display_json_values(document.creator).to_sentence %> </span>
+      <span class="text-center"><%= display_json_values(document.creator).try(:to_sentence) %> </span>
     </div>
   </td>
   <td>


### PR DESCRIPTION
Ensure we don't iterate over nil.

Creator metadata is supposed to always return an array even when empty? but just incase of nil which is unlikely, I am calling the try method when calling to_sentence. Eg
(document.creator).try(:to_sentence)