### PR TITLE
ensure review submission page renders json correctly

### DIFF
--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -1,0 +1,97 @@
+<!-- Copied by UbiquityPress from https://github.com/samvera/hyrax/blob/v2.0.2/app/views/hyrax/admin/workflows/index.html.erb
+  to fix json display on review submission page -->
+
+  <% provide :page_header do %>
+  <h1><span class="glyphicon glyphicon-ok-circle"></span> <%= t('.header') %></h1>
+<% end %>
+
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default tabs">
+      <ul class="nav nav-tabs" role="tablist">
+        <li class="active">
+          <a href="#under-review" role="tab" data-toggle="tab"><%= t('.tabs.under_review') %></a>
+        </li>
+        <li>
+          <a href="#published" role="tab" data-toggle="tab"><%= t('.tabs.published') %></a>
+        </li>
+      </ul>
+      <div class="tab-content">
+        <div id="under-review" class="tab-pane active">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <div class="table-responsive">
+                <table class="table table-condensed table-striped datatable">
+                  <thead>
+                    <tr>
+                      <th width="40%">Work</th>
+                      <th width="20%">Depositor</th>
+                      <th width="20%">Submission Date</th>
+                      <th width="20%">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% @status_list.each do |document| %>
+                      <tr>
+                        <td>
+                          <%= link_to document, [main_app, document] %>
+                        </td>
+                        <td>
+                          <%= document.depositor %>
+                        </td>
+                        <td>
+                          <%= document.date_modified %>
+                        </td>
+                        <td>
+                          <span class="state state-pending"><%= document.workflow_state %></span>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="published" class="tab-pane">
+          <div class="panel panel-default labels">
+            <div class="panel-body">
+              <div class="table-responsive">
+                <table class="table table-condensed table-striped datatable">
+                  <thead>
+                    <tr>
+                      <th width="40%">Work</th>
+                      <th width="20%">Depositor</th>
+                      <th width="20%">Submission Date</th>
+                      <th width="20%">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% @published_list.each do |document| %>
+                      <tr>
+                        <td>
+                          <%= link_to document, [main_app, document] %>
+                        </td>
+                        <td>
+                          <!-- added by UbiquityPress replacing  safe_join(document.creator, tag(:br)) -->
+                          <%= display_json_values(document.creator).try(:to_sentence) %>
+                        </td>
+                        <td>
+                          <%= document.date_modified %>
+                        </td>
+                        <td>
+                          <span class="state state-pending"><%= document.workflow_state %></span>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Fixes https://trello.com/c/ndkaPaYV/322-dashboard-review-submissions-depositor-column-shows-json-code-instead-of-name

Previous look:
![screenshot from 2018-10-25 15-27-29](https://user-images.githubusercontent.com/329514/47509229-92291180-d86d-11e8-818f-2af466125298.png)

Look after fix:
![screenshot from 2018-10-25 15-29-30](https://user-images.githubusercontent.com/329514/47509256-a40ab480-d86d-11e8-8be9-0576fca4a782.png)
