### PR TITLE
Remove all view options from search/browse

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,9 +14,10 @@ class CatalogController < ApplicationController
   end
 
   configure_blacklight do |config|
-    config.view.gallery.partials = %i[index_header index]
-    config.view.masonry.partials = [:index]
-    config.view.slideshow.partials = [:index]
+    #commented out by UbiquityPress
+    #config.view.gallery.partials = %i[index_header index]
+    #config.view.masonry.partials = [:index]
+    #config.view.slideshow.partials = [:index]
 
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
     config.show.partials.insert(1, :openseadragon)
@@ -29,9 +30,10 @@ class CatalogController < ApplicationController
 
     config.search_builder_class = Hyrax::CatalogSearchBuilder
 
+    #commented out by UbiquityPress
     # Show gallery view
-    config.view.gallery.partials = %i[index_header index]
-    config.view.slideshow.partials = [:index]
+    #config.view.gallery.partials = %i[index_header index]
+    #config.view.slideshow.partials = [:index]
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {


### PR DESCRIPTION
Remove all view options from search/browse
Resolves: https://trello.com/c/YmTaK3Qq/335-remove-all-view-options-from-search-browse