### PR TITLE
Make sure docker-compose works if adding new gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM upress/hyku-base:latest
 
 ADD . /data
 
+RUN gem install bundler
+
+RUN bundle install
+
 RUN bundle exec rake assets:precompile
 
 EXPOSE 3000

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -29,5 +29,3 @@ RUN apt-get update && \
 
 ADD Gemfile /data/Gemfile
 ADD Gemfile.lock /data/Gemfile.lock
-
-RUN bundle install


### PR DESCRIPTION
Fixes issue with spinning up environment (after adding `chosen-rails` gem).

Docker-compose build was failing:

```Building web
Step 1/5 : FROM upress/hyku-base:latest
 ---> e745c72c81e8
Step 2/5 : ADD . /data
 ---> 3424462d7548
Step 3/5 : RUN bundle exec rake assets:precompile
 ---> Running in 0fd1f92aa751
bundler: failed to load command: rake (/usr/local/bundle/bin/rake)
Bundler::GemNotFound: Could not find chosen-rails-1.8.7 in any of the sources
```