### PR TITLE
Fix empty 'Article number' field display in Works show page

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -30,7 +30,7 @@
 <%= presenter.attribute_to_html(:isbn, label: "ISBN", render_as: :string) %>
 <%= presenter.attribute_to_html(:issn, label: "ISSN", render_as: :string) %>
 <%= presenter.attribute_to_html(:eissn, label: "eISSN", render_as: :string) %>
-<%= presenter.attribute_to_html(:article_num, label: "Article number") %>
+<%= presenter.attribute_to_html(:article_num, label: "Article number", render_as: :string) %>
 <%= presenter.attribute_to_html(:doi, label: "DOI", render_as: :external_url) %>
 <%= presenter.attribute_to_html(:org_unit, label: "Organisational unit") %>
 <%= presenter.attribute_to_html(:project_name, render_as: :string) %>


### PR DESCRIPTION
Following #144 