### PR TITLE
Change display in creator facet

### DIFF
--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -30,6 +30,9 @@ module Ubiquity
     #    c. Save the the array of hashes from step 2b
     #
     def save_creator
+
+      self.creator_group ||= JSON.parse(self.creator.first) if self.creator.present?
+
       #remove Hash with empty values and nil
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.creator_group)
 
@@ -48,6 +51,7 @@ module Ubiquity
     end
 
     def save_contributor
+      self.contributor_group ||= JSON.parse(self.contributor.first) if self.contributor.present?
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.contributor_group)
       data = compare_hash_keys?(clean_submitted_data)
       if (self.contributor_group.present? && clean_submitted_data.present? && data == false )
@@ -59,6 +63,7 @@ module Ubiquity
     end
 
     def save_related_identifier
+      self.related_identifier_group ||= JSON.parse(self.related_identifier.first) if self.related_identifier.present?
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.related_identifier_group)
       data = compare_hash_keys?(clean_submitted_data)
       if (self.related_identifier_group.present?  && clean_submitted_data.present? && data == false)
@@ -70,6 +75,7 @@ module Ubiquity
     end
 
     def save_alternate_identifier
+      self.alternate_identifier_group ||= JSON.parse(self.alternate_identifier.first) if self.alternate_identifier.present?
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.alternate_identifier_group)
       data = compare_hash_keys?(clean_submitted_data)
       if (self.alternate_identifier_group.present? && clean_submitted_data.present? && data == false)

--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -41,6 +41,7 @@ module Ubiquity
         populate_creator_search_field(creator_json)
         self.creator = [creator_json]
       elsif data == true || data == nil
+        self.creator_search = []
         #save an empty array since the submitted data contains only default keys & values
         self.creator = []
       end

--- a/app/models/concerns/ubiquity/editor_metadata_model_concern.rb
+++ b/app/models/concerns/ubiquity/editor_metadata_model_concern.rb
@@ -19,6 +19,7 @@ module Ubiquity
     private
 
     def save_editor
+      self.editor_group ||= JSON.parse(self.editor.first) if self.editor.present?
       #remove Hash with empty values and nil
       clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.editor_group)
 

--- a/app/services/ubiquity/parse_json.rb
+++ b/app/services/ubiquity/parse_json.rb
@@ -25,7 +25,8 @@ module Ubiquity
         #This means the script is idempotent, which for our use case means that you can re-run it several times without creating duplicates
         value = []
         value |= [hash["creator_family_name"].to_s]
-        value << (', ' + hash["creator_given_name"].to_s) if hash["creator_given_name"].present?
+        value |= [', '] if hash["creator_family_name"].present? && hash["creator_given_name"].present?
+        value |= [hash["creator_given_name"].to_s]
         value |= [hash["creator_organization_name"]]
         value_arr << value.reject(&:blank?).join
       end

--- a/app/services/ubiquity/parse_json.rb
+++ b/app/services/ubiquity/parse_json.rb
@@ -6,12 +6,15 @@ module Ubiquity
       @data = json_data
     end
 
+    def parsed_json
+      if @data.present? && @data.class == Array && @data.first.class == String
+        JSON.parse(@data.first)
+      elsif @data.class == String
+        JSON.parse(@data)
+      end
+    end
+
     def data
-      parsed_json = if @data.present? && @data.class == Array && @data.first.class == String
-                      JSON.parse(@data.first)
-                    elsif @data.class == String
-                      JSON.parse(@data)
-                    end
       transform_data(parsed_json) if parsed_json.present?
     end
 

--- a/app/services/ubiquity/parse_json.rb
+++ b/app/services/ubiquity/parse_json.rb
@@ -16,17 +16,17 @@ module Ubiquity
     end
 
     def transform_data(parsed_json)
-      value = []
-      record = parsed_json.map do |hash|
+      value_arr = []
+      parsed_json.map do |hash|
         # we are using the union literal  '|' which is used to combine the unique values of two arrays
         #This means the script is idempotent, which for our use case means that you can re-run it several times without creating duplicates
-        value |= [(hash["creator_given_name"].to_s + ' ' + hash["creator_family_name"].to_s)]
+        value = []
+        value |= [hash["creator_family_name"].to_s]
+        value << (', ' + hash["creator_given_name"].to_s) if hash["creator_given_name"].present?
         value |= [hash["creator_organization_name"]]
-        value
+        value_arr << value.reject(&:blank?).join
       end
-      value.reject(&:blank?).compact
-
+      value_arr
     end
-
   end
 end

--- a/lib/tasks/creator_search.rake
+++ b/lib/tasks/creator_search.rake
@@ -15,45 +15,12 @@ namespace :creator_search do
     model_class.each do |model|
       #We fetching an instance of the models and then getting the value in the creator field
       model.find_each do |model_instance|
-        if model_instance.model_name != "Collection"
-          json_creator_record = model_instance.creator.first
-          contributor_record = Ubiquity::ParseJson.new(model_instance.contributor.first).parsed_json
-          alt_id_record = Ubiquity::ParseJson.new(model_instance.alternate_identifier.first).parsed_json
-          related_id_record = Ubiquity::ParseJson.new(model_instance.related_identifier.first).parsed_json
-          if json_creator_record.present?
-            #We parse the json in the an array before saving the value in creator_search
-            values = Ubiquity::ParseJson.new(json_creator_record).data
-            if model_instance.respond_to?(:editor)
-              editor_record = Ubiquity::ParseJson.new(model_instance.editor.first).parsed_json
-              model_instance.update(creator_search: values,
-                                    creator_group:  Ubiquity::ParseJson.new(json_creator_record).parsed_json,
-                                    contributor_group: contributor_record,
-                                    alternate_identifier_group: alt_id_record,
-                                    related_identifier_group: related_id_record,
-                                    editor_group: editor_record)
-            else
-              model_instance.update(creator_search: values,
-                                    creator_group: Ubiquity::ParseJson.new(json_creator_record).parsed_json,
-                                    contributor_group: contributor_record,
-                                    alternate_identifier_group: alt_id_record,
-                                    related_identifier_group: related_id_record)
-            end
-            sleep 2
-          else
-            if model_instance.respond_to?(:editor)
-              model_instance.update(creator_search: [],
-                                    contributor_group: contributor_record,
-                                    alternate_identifier_group: alt_id_record,
-                                    related_identifier_group: related_id_record,
-                                    editor_group: editor_record)
-            else
-              model_instance.update(creator_search: [],
-                                    contributor_group: contributor_record,
-                                    alternate_identifier_group: alt_id_record,
-                                    related_identifier_group: related_id_record)
-            end
-            sleep 2
-          end
+        json_record = model_instance.creator.first
+        if json_record.present?
+          #We parse the json in the an array before saving the value in creator_search
+          values = Ubiquity::ParseJson.new(json_record).data
+          model_instance.update(creator_search: values)
+          sleep 2
         end
       end
     end


### PR DESCRIPTION
- Filter from last name, like "Doe, Jane" Instead of "Jane Doe"
- Make sure the `creator_search` field is erased too when a creator is deleted.
- Changes to rake task so json "virtual fields" data is not lost.

Follow up on #109 

Trello #[276](https://trello.com/c/ENyC6Tmb)