### PR TITLE
Change 'Date published' from String to Date field...

### DIFF
--- a/app/assets/stylesheets/ubiquity.scss
+++ b/app/assets/stylesheets/ubiquity.scss
@@ -65,6 +65,11 @@ h4, .homepage-nav-tabs {
   width: 46%;
 }
 
+.ubiquity-date-input {
+  display: inline-block;
+  width: 30%;
+}
+
 .ubiquity_isni_image {
    height: 16;
    width: 44;

--- a/app/forms/ubiquity/all_forms_shared_behaviour.rb
+++ b/app/forms/ubiquity/all_forms_shared_behaviour.rb
@@ -12,7 +12,8 @@ module Ubiquity
                     :creator_family_name, :creator_orcid, :creator_isni,
                     :creator_position, :creator_institutional_relationship
 
-      attr_accessor :alternate_identifier_group, :related_identifier_group, :date_published_group
+      attr_accessor :alternate_identifier_group, :related_identifier_group,
+                    :date_published_group, :date_accepted_group, :date_submitted_group
 
       attr_accessor :note
 
@@ -58,6 +59,8 @@ module Ubiquity
           permitted_params << { related_identifier_group: %i[related_identifier related_identifier_type relation_type] }
 
           permitted_params << { date_published_group: %i[date_published_year date_published_month date_published_day] }
+          permitted_params << { date_accepted_group: %i[date_accepted_year date_accepted_month date_accepted_day] }
+          permitted_params << { date_submitted_group: %i[date_submitted_year date_submitted_month date_submitted_day] }
         end
       end
     end # closes class class_methods

--- a/app/forms/ubiquity/all_forms_shared_behaviour.rb
+++ b/app/forms/ubiquity/all_forms_shared_behaviour.rb
@@ -12,7 +12,7 @@ module Ubiquity
                     :creator_family_name, :creator_orcid, :creator_isni,
                     :creator_position, :creator_institutional_relationship
 
-      attr_accessor :alternate_identifier_group, :related_identifier_group
+      attr_accessor :alternate_identifier_group, :related_identifier_group, :date_published_group
 
       attr_accessor :note
 
@@ -57,6 +57,7 @@ module Ubiquity
 
           permitted_params << { related_identifier_group: %i[related_identifier related_identifier_type relation_type] }
 
+          permitted_params << { date_published_group: %i[date_published_year date_published_month date_published_day] }
         end
       end
     end # closes class class_methods

--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -9,10 +9,12 @@ module Ubiquity
       before_save :save_creator
       before_save :save_alternate_identifier
       before_save :save_related_identifier
+      before_save :save_date_published
 
       #These are used in the forms to populate fields that will be stored in json fields
       #The json fields in this case are creator, contributor, alternate_identifier and related_identifier
-      attr_accessor :creator_group, :contributor_group, :alternate_identifier_group, :related_identifier_group
+      attr_accessor :creator_group, :contributor_group, :alternate_identifier_group, :related_identifier_group,
+                    :date_published_group
     end
 
     private
@@ -30,7 +32,6 @@ module Ubiquity
     #    c. Save the the array of hashes from step 2b
     #
     def save_creator
-
       self.creator_group ||= JSON.parse(self.creator.first) if self.creator.present?
 
       #remove Hash with empty values and nil
@@ -86,6 +87,25 @@ module Ubiquity
       elsif data == true || data == nil
         self.alternate_identifier = []
       end
+    end
+
+    def save_date_published
+      date_published = ""
+      # iterate over year, month, day to obtain a String in format: 'YYYYMMDD'
+      # see 'all_forms_shared_behaviour'
+      date_published_group.first.each do |key, value|
+        if value.present?
+          if value.length > 1
+            date_published << value
+          else
+            date_published << '0' << value
+          end
+        else
+          date_published << '01'
+        end
+      end
+      d = Date.parse(date_published)
+      self.date_published = d
     end
 
     private

--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -9,12 +9,12 @@ module Ubiquity
       before_save :save_creator
       before_save :save_alternate_identifier
       before_save :save_related_identifier
-      before_save :save_date_published
+      before_save :save_date_published, :save_date_accepted, :save_date_submitted
 
       #These are used in the forms to populate fields that will be stored in json fields
       #The json fields in this case are creator, contributor, alternate_identifier and related_identifier
       attr_accessor :creator_group, :contributor_group, :alternate_identifier_group, :related_identifier_group,
-                    :date_published_group
+                    :date_published_group, :date_accepted_group, :date_submitted_group
     end
 
     private
@@ -90,22 +90,15 @@ module Ubiquity
     end
 
     def save_date_published
-      date_published = ""
-      # iterate over year, month, day to obtain a String in format: 'YYYYMMDD'
-      # see 'all_forms_shared_behaviour'
-      date_published_group.first.each do |key, value|
-        if value.present?
-          if value.length > 1
-            date_published << value
-          else
-            date_published << '0' << value
-          end
-        else
-          date_published << '01'
-        end
-      end
-      d = Date.parse(date_published)
-      self.date_published = d
+      self.date_published = transform_date_group(date_published_group.first)
+    end
+
+    def save_date_accepted
+      self.date_accepted = transform_date_group(date_accepted_group.first)
+    end
+
+    def save_date_submitted
+      self.date_submitted = transform_date_group(date_submitted_group.first)
     end
 
     private
@@ -159,6 +152,24 @@ module Ubiquity
         return   ["#{get_field_name}_position"] if (data.length == 1 && splitted_record.last == "position")
         ["#{get_field_name}_name_type", "#{get_field_name}_position"]
       end
+    end
+
+    def transform_date_group(hash)
+      date = ""
+      # iterate over year, month, day to obtain a String in format: 'YYYYMMDD'
+      # see 'all_forms_shared_behaviour'
+      hash.each do |key, value|
+        if value.present?
+          if value.length > 1
+            date << value
+          else
+            date << '0' << value
+          end
+        else
+          date << '01'
+        end
+      end
+      Date.parse(date)
     end
 
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,7 +34,7 @@ class SolrDocument
   attribute :funder, Solr::Array, solr_name('funder')
   attribute :fndr_project_ref, Solr::Array, solr_name('fndr_project_ref')
   attribute :add_info, Solr::Array, solr_name('add_info')
-  attribute :date_published, Solr::Array, solr_name('date_published')
+  # attribute :date_published, Solr::Array, solr_name('date_published') see `manifest_enabled_work_show_presenter`
   attribute :date_accepted, Solr::Array, solr_name('date_accepted')
   attribute :date_submitted, Solr::Array, solr_name('date_submitted')
   attribute :journal_title, Solr::Array, solr_name('journal_title')

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -35,8 +35,8 @@ class SolrDocument
   attribute :fndr_project_ref, Solr::Array, solr_name('fndr_project_ref')
   attribute :add_info, Solr::Array, solr_name('add_info')
   # attribute :date_published, Solr::Array, solr_name('date_published') see `manifest_enabled_work_show_presenter`
-  attribute :date_accepted, Solr::Array, solr_name('date_accepted')
-  attribute :date_submitted, Solr::Array, solr_name('date_submitted')
+  # attribute :date_accepted, Solr::Array, solr_name('date_accepted')
+  # attribute :date_submitted, Solr::Array, solr_name('date_submitted')
   attribute :journal_title, Solr::Array, solr_name('journal_title')
   attribute :issue, Solr::Array, solr_name('issue')
   attribute :volume, Solr::Array, solr_name('volume')

--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -3,7 +3,7 @@ module Hyku
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyku::FileSetPresenter
 
     delegate :extent, :rendering_ids, :isni, :institution, :org_unit, :refereed, :doi, :isbn, :issn, :eissn,
-             :funder, :fndr_project_ref, :add_info, :date_published, :date_accepted, :date_submitted,
+             :funder, :fndr_project_ref, :add_info, :date_accepted, :date_submitted,
              :journal_title, :issue, :volume, :pagination, :article_num, :project_name, :rights_holder,
              :official_link, :place_of_publication, :series_name, :edition, :abstract, :version,
              :event_title, :event_date, :event_location, :book_title, :editor,
@@ -74,6 +74,15 @@ module Hyku
       solr_document['edit_access_person_ssim']
     end
 
+    def date_published
+      date = solr_document['date_published_dtsim']
+      if date.present?
+        return Date.parse(date.first).strftime("%F") unless date.first[(8..9)] == "01"
+        return Date.parse(date.first).strftime("%Y-%m") if date.first[(5..9)] != "01-01"
+        return Date.parse(date.first).strftime("%Y")
+      end
+      solr_document['date_published_tesim']
+    end
 
     private
 

--- a/app/views/records/edit_fields/_date_accepted.html.erb
+++ b/app/views/records/edit_fields/_date_accepted.html.erb
@@ -1,0 +1,2 @@
+<% date_accepted = f.object[:date_accepted] %>
+<%= render 'shared/ubiquity/date_accepted', f: f, date_accepted: date_accepted %>

--- a/app/views/records/edit_fields/_date_published.html.erb
+++ b/app/views/records/edit_fields/_date_published.html.erb
@@ -1,0 +1,2 @@
+<% date_published = f.object[:date_published] %>
+<%= render 'shared/ubiquity/date_published', f: f, date_published: date_published %>

--- a/app/views/records/edit_fields/_date_submitted.html.erb
+++ b/app/views/records/edit_fields/_date_submitted.html.erb
@@ -1,0 +1,2 @@
+<% date_submitted = f.object[:date_submitted] %>
+<%= render 'shared/ubiquity/date_submitted', f: f, date_submitted: date_submitted %>

--- a/app/views/shared/ubiquity/_date_accepted.html.erb
+++ b/app/views/shared/ubiquity/_date_accepted.html.erb
@@ -1,0 +1,37 @@
+<%# see app/views/records/edit_fields/_date_published.html.erb %>
+<% template = @curation_concern.class.to_s.underscore %>
+<% months = (1..12).to_a %>
+<% days = (1..31).to_a %>
+<% years = ((Date.today.year - 200)..(Date.today.year)).to_a.reverse %>
+
+<label class="control-label" for="date_accepted">Date accepted</label>
+<p class="help-block"><%= t('simple_form.hints.defaults.date_accepted') %></p>
+
+<% if date_accepted.present? %>
+  <%= select_tag "#{template}[date_accepted_group][][date_accepted_year]",
+                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i', date_accepted.try(:strftime, "%Y").to_i)),
+                 required: true, class: 'form-control ubiquity-date-input'
+  %>
+  <%= select_tag "#{template}[date_accepted_group][][date_accepted_month]",
+                 content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months), 'to_i', 'to_i', date_accepted.try(:strftime, "%m").to_i),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+  <%= select_tag "#{template}[date_accepted_group][][date_accepted_day]",
+                 content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days), 'to_i', 'to_i', date_accepted.try(:strftime, "%d").to_i),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+<% else %>
+  <%= select_tag "#{template}[date_accepted_group][][date_accepted_year]",
+                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i')),
+                 required: true, class: 'form-control ubiquity-date-input'
+  %>
+  <%= select_tag "#{template}[date_accepted_group][][date_accepted_month]",
+                 content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months), 'to_i', 'to_i'),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+  <%= select_tag "#{template}[date_accepted_group][][date_accepted_day]",
+                 content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days), 'to_i', 'to_i'),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+<% end %>
+<br/><br/><br/>

--- a/app/views/shared/ubiquity/_date_accepted.html.erb
+++ b/app/views/shared/ubiquity/_date_accepted.html.erb
@@ -9,7 +9,7 @@
 
 <% if date_accepted.present? %>
   <%= select_tag "#{template}[date_accepted_group][][date_accepted_year]",
-                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i', date_accepted.try(:strftime, "%Y").to_i)),
+                 content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years), 'to_i', 'to_i', date_accepted.try(:strftime, "%Y").to_i),
                  required: true, class: 'form-control ubiquity-date-input'
   %>
   <%= select_tag "#{template}[date_accepted_group][][date_accepted_month]",
@@ -22,7 +22,7 @@
   %>
 <% else %>
   <%= select_tag "#{template}[date_accepted_group][][date_accepted_year]",
-                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i')),
+                 content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years), 'to_i', 'to_i'),
                  required: true, class: 'form-control ubiquity-date-input'
   %>
   <%= select_tag "#{template}[date_accepted_group][][date_accepted_month]",

--- a/app/views/shared/ubiquity/_date_published.html.erb
+++ b/app/views/shared/ubiquity/_date_published.html.erb
@@ -11,7 +11,7 @@
 
 <% if date_published.present? %>
   <%= select_tag "#{template}[date_published_group][][date_published_year]",
-                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i', date_published.try(:strftime, "%Y").to_i)),
+                 content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years), 'to_i', 'to_i', date_published.try(:strftime, "%Y").to_i),
                  required: true, class: 'form-control ubiquity-date-input'
   %>
   <%= select_tag "#{template}[date_published_group][][date_published_month]",
@@ -24,7 +24,7 @@
   %>
 <% else %>
   <%= select_tag "#{template}[date_published_group][][date_published_year]",
-                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i')),
+                 content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years), 'to_i', 'to_i'),
                  required: true, class: 'form-control ubiquity-date-input'
   %>
   <%= select_tag "#{template}[date_published_group][][date_published_month]",

--- a/app/views/shared/ubiquity/_date_published.html.erb
+++ b/app/views/shared/ubiquity/_date_published.html.erb
@@ -1,0 +1,39 @@
+<%# see app/views/records/edit_fields/_date_published.html.erb %>
+<% template = @curation_concern.class.to_s.underscore %>
+<% months = (1..12).to_a %>
+<% days = (1..31).to_a %>
+<% years = ((Date.today.year - 200)..(Date.today.year)).to_a.reverse %>
+
+<label class="control-label" for="date_published">
+  Date published <span class="label label-info required-tag">required</span>
+</label>
+<p class="help-block"><%= t('simple_form.hints.defaults.date_published') %></p>
+
+<% if date_published.present? %>
+  <%= select_tag "#{template}[date_published_group][][date_published_year]",
+                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i', date_published.try(:strftime, "%Y").to_i)),
+                 required: true, class: 'form-control ubiquity-date-input'
+  %>
+  <%= select_tag "#{template}[date_published_group][][date_published_month]",
+                 content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months), 'to_i', 'to_i', date_published.try(:strftime, "%m").to_i),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+  <%= select_tag "#{template}[date_published_group][][date_published_day]",
+                 content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days), 'to_i', 'to_i', date_published.try(:strftime, "%d").to_i),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+<% else %>
+  <%= select_tag "#{template}[date_published_group][][date_published_year]",
+                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i')),
+                 required: true, class: 'form-control ubiquity-date-input'
+  %>
+  <%= select_tag "#{template}[date_published_group][][date_published_month]",
+                 content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months), 'to_i', 'to_i'),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+  <%= select_tag "#{template}[date_published_group][][date_published_day]",
+                 content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days), 'to_i', 'to_i'),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+<% end %>
+<br/><br/><br/>

--- a/app/views/shared/ubiquity/_date_submitted.html.erb
+++ b/app/views/shared/ubiquity/_date_submitted.html.erb
@@ -1,0 +1,37 @@
+<%# see app/views/records/edit_fields/_date_published.html.erb %>
+<% template = @curation_concern.class.to_s.underscore %>
+<% months = (1..12).to_a %>
+<% days = (1..31).to_a %>
+<% years = ((Date.today.year - 200)..(Date.today.year)).to_a.reverse %>
+
+<label class="control-label" for="date_published">Date submitted</label>
+<p class="help-block"><%= t('simple_form.hints.defaults.date_submitted') %></p>
+
+<% if date_submitted.present? %>
+  <%= select_tag "#{template}[date_submitted_group][][date_submitted_year]",
+                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i', date_submitted.try(:strftime, "%Y").to_i)),
+                 required: true, class: 'form-control ubiquity-date-input'
+  %>
+  <%= select_tag "#{template}[date_submitted_group][][date_submitted_month]",
+                 content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months), 'to_i', 'to_i', date_submitted.try(:strftime, "%m").to_i),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+  <%= select_tag "#{template}[date_submitted_group][][date_submitted_day]",
+                 content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days), 'to_i', 'to_i', date_submitted.try(:strftime, "%d").to_i),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+<% else %>
+  <%= select_tag "#{template}[date_submitted_group][][date_submitted_year]",
+                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i')),
+                 required: true, class: 'form-control ubiquity-date-input'
+  %>
+  <%= select_tag "#{template}[date_submitted_group][][date_submitted_month]",
+                 content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months), 'to_i', 'to_i'),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+  <%= select_tag "#{template}[date_submitted_group][][date_submitted_day]",
+                 content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days), 'to_i', 'to_i'),
+                 {:class => 'form-control ubiquity-date-input'}
+  %>
+<% end %>
+<br/><br/><br/>

--- a/app/views/shared/ubiquity/_date_submitted.html.erb
+++ b/app/views/shared/ubiquity/_date_submitted.html.erb
@@ -9,7 +9,7 @@
 
 <% if date_submitted.present? %>
   <%= select_tag "#{template}[date_submitted_group][][date_submitted_year]",
-                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i', date_submitted.try(:strftime, "%Y").to_i)),
+                 content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years), 'to_i', 'to_i', date_submitted.try(:strftime, "%Y").to_i),
                  required: true, class: 'form-control ubiquity-date-input'
   %>
   <%= select_tag "#{template}[date_submitted_group][][date_submitted_month]",
@@ -22,7 +22,7 @@
   %>
 <% else %>
   <%= select_tag "#{template}[date_submitted_group][][date_submitted_year]",
-                 content_tag(:option, options_from_collection_for_select((years), 'to_i', 'to_i')),
+                 content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years), 'to_i', 'to_i'),
                  required: true, class: 'form-control ubiquity-date-input'
   %>
   <%= select_tag "#{template}[date_submitted_group][][date_submitted_month]",


### PR DESCRIPTION
...to enable date picker; with required year only.

Trello #[173](https://trello.com/c/Obcim9jp)

Also changes `date_submitted`, `date_accepted`.
Because we need to require only a year while making it possible to also add a month and day, we cannot use a single `f.input :date_published` and instead are using the 'virtual fields' pattern.