### PR TITLE
Fix problem caused by renaming tenant account cname

### DIFF
--- a/app/jobs/create_fcrepo_endpoint_job.rb
+++ b/app/jobs/create_fcrepo_endpoint_job.rb
@@ -4,6 +4,13 @@ class CreateFcrepoEndpointJob < ActiveJob::Base
   def perform(account)
     name = account.tenant.parameterize
 
-    account.create_fcrepo_endpoint(base_path: "/#{name}")
+    account.create_fcrepo_endpoint(base_path: "/#{name}", url: fedora_url)
   end
+
+  private
+
+    def fedora_url
+      uri = URI(Settings.fedora.url)
+      uri.to_s
+    end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,3 +63,6 @@ devise:
   account_signup: false
   # The address from which user invitations are sent
   invitation_from_email: "change-me-in-hyku-settings@example.org"
+
+fedora:
+  url: "http://fcrepo:8080/fcrepo/rest"


### PR DESCRIPTION
Trello #[285](https://trello.com/c/IXOS45lc)

When renaming a tenant from `<host>/proprietor/accounts/<id>/edit`, the Fedora endpoint `url` is currently nil, which brings the site down.
The changes in this PR save a correct `fcrepo_endpoint.url` on Account **Creation**.

:warning:  When **editing** an existing tenant account - which was saved prior to this code change, hence does not have a Fedora Endpoint URL - the 1st time, we need to type in the missing value: `http://fcrepo:8080/fcrepo/rest`

![screenshot from 2018-11-23 15-28-38](https://user-images.githubusercontent.com/26539307/48950867-84ca7a00-ef34-11e8-939f-29f5516eb1ec.png)


In rails console, see: `Account.find(<id>).fcrepo_endpoint.url` 