### PR TITLE
Datacite doi

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,3 +124,6 @@ gem 'secure_headers'
 gem 'honeybadger', '~> 3.0'
 
 gem 'sentry-raven'
+
+#added by Ubiquity 
+gem 'httparty', '~> 0.16.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,8 @@ GEM
       mimemagic
       multipart-post
     http_logger (0.5.1)
-    httparty (0.16.1)
+    httparty (0.16.3)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     hydra-access-controls (10.5.0)
@@ -926,6 +927,7 @@ DEPENDENCIES
   fcrepo_wrapper (~> 0.4)
   flipflop (~> 2.3)
   honeybadger (~> 3.0)
+  httparty (~> 0.16.3)
   hyrax (= 2.0.2)
   i18n-debug
   i18n-tasks

--- a/app/assets/stylesheets/ubiquity.scss
+++ b/app/assets/stylesheets/ubiquity.scss
@@ -89,3 +89,7 @@ h4, .homepage-nav-tabs {
 .note-body {
   padding-top: 16px;
 }
+
+.ubiquity-modal-padding {
+  padding: 16px 0px 8px 0px;
+}

--- a/app/controllers/available_ubiquity_titles_controller.rb
+++ b/app/controllers/available_ubiquity_titles_controller.rb
@@ -10,4 +10,11 @@ class AvailableUbiquityTitlesController < ApplicationController
        render json: {"data": 'false', "message": "Title is available"}
      end
   end
+
+  def call_datasite
+    url = params["url"]
+    datacite = Ubiquity::DataciteClient.new(url).fetch_record
+    render json: {'data': datacite.data}
+  end
+
 end

--- a/app/services/ubiquity/datacite_client.rb
+++ b/app/services/ubiquity/datacite_client.rb
@@ -1,0 +1,61 @@
+module Ubiquity
+  class DataciteClient
+    include HTTParty
+    base_uri 'https://api.datacite.org'
+    default_timeout 6
+
+    attr_accessor :path
+
+    def initialize(url)
+      #@path = path
+      #sets the value of the path ,ethod
+      parse_url(url)
+    end
+
+    def fetch_record
+      #result = self.class.get("/works/#{path}")
+      result = self.class.get("#{path}")
+      response_object(result)
+    end
+
+    private
+
+    def response_object(result)
+      response_hash = result.parsed_response
+      Ubiquity::DataciteResponse.new(response_hash)
+    end
+
+    def parse_url(url)
+      uri = URI.parse(url)
+      if (uri.scheme.present? &&  uri.host.present?)
+        path_name = uri.path
+        use_path(path_name)
+      elsif (uri.scheme.present? == false && uri.host.present? == false && uri.path.present?)
+        use_path(uri.path)
+      end
+    end
+
+    def use_path(path_name)
+      puts "uri #{path_name}"
+      split_path = path_name.split('/').reject(&:empty?)
+      if split_path.length == 3 && split_path.first == 'works'
+        #changes "works/10.5438/0012" to "/works/10.5438/0012"
+        path_name = path_name.prepend('/') if path_name.slice(0) != "/"
+        @path = path_name
+      elsif split_path.length == 4 && split_path.first == 'api.datacite.org'
+        #data here is ["api.datacite.org", "works", "10.5438", "0012"]
+        #shift removes the first element
+        split_path.shift
+        #we get back "works/#{path_name}"
+        url_path =split_path.join('/')
+        #we get back "/works/#{path_name}"
+        new_url_path = url_path.prepend('/')
+        @path = new_url_path
+      elsif split_path.length == 2 && (not split_path.include? 'works')
+        path_name = path_name.prepend('/') if path_name.slice(0) != "/"
+        @path = "/works/#{path_name}"
+      end
+    end
+
+  end
+end

--- a/app/services/ubiquity/datacite_response.rb
+++ b/app/services/ubiquity/datacite_response.rb
@@ -1,14 +1,16 @@
 module Ubiquity
   class DataciteResponse
-    attr_accessor :api_response
+    attr_accessor :api_response, :error
      attr_reader :raw_http_response, :attributes
 
      #parsed_response_hash is httparty response body
-     def initialize(response_hash, result=nil)
+     def initialize(response_hash: nil, result: nil, error: nil)
        @api_response = response_hash
        @raw_http_response = result
-       @attributes =  response_hash['data']['attributes']
-
+       @error = error
+       if response_hash != nil && response_hash.class == Hash
+         @attributes =  response_hash['data']['attributes'] 
+       end
        self
      end
 
@@ -57,24 +59,29 @@ module Ubiquity
 
      def auto_populated_fields
        fields = []
-       fields << 'related_identifier' if related_identifier.present?
+       fields << 'creator' if creator.present?
        fields << 'title' if title.present?
        fields << "published" if date_published_year.present?
-       fields << 'creator' if creator.present?
+       fields << 'related_identifier' if related_identifier.present?
        fields << 'abstract' if abstract.present?
-       fields << 'version' if version.present?
        fields << 'license' if license.present?
+       #fields << 'version' if version.present?
+
        "The following fields were auto-populated - #{fields.to_sentence}"
      end
 
      def data
-       {
-         'related_identifier_group': related_identifier,
-         "title": title, "published": date_published_year,
-         "abstract": abstract, "version": version,
-         "creator_group": creator, license: license,
-         "auto_populated": auto_populated_fields
-      }
+       if error.present?
+         {'error' => error}
+       else
+         {
+           'related_identifier_group': related_identifier,
+           "title": title, "published": date_published_year,
+           "abstract": abstract, "version": version,
+            "creator_group": creator, license: license,
+            "auto_populated": auto_populated_fields
+         }
+    end
 
      end
 

--- a/app/services/ubiquity/datacite_response.rb
+++ b/app/services/ubiquity/datacite_response.rb
@@ -1,0 +1,116 @@
+module Ubiquity
+  class DataciteResponse
+    attr_accessor :api_response
+     attr_reader :raw_http_response, :attributes
+
+     #parsed_response_hash is httparty response body
+     def initialize(response_hash, result=nil)
+       @api_response = response_hash
+       @raw_http_response = result
+       @attributes =  response_hash['data']['attributes']
+
+       self
+     end
+
+     def title
+       attributes['title']
+     end
+
+     def date_published_year
+       attributes['published']
+     end
+
+     def abstract
+       attributes['description']
+     end
+
+     def version
+       attributes.dig('version')
+     end
+
+     def license
+       attributes.dig('license')
+     end
+
+     def creator
+       creator_group = attributes.dig('author')
+       if (creator_group.first.keys.include? "given") || (creator_group.first.keys.include? "family")
+         creator_with_seperated_names(creator_group)
+       else
+         creator_without_seperated_names(creator_group)
+       end
+
+     end
+
+    #[{"relation-type-id"=>"Documents", "related-identifier"=>"https://doi.org/10.5438/0013"}, {"relation-type-id"=>"IsNewVersionOf", "related-identifier"=>"https://doi.org/10.5438/0010"}]
+     def related_identifier
+       related_group = attributes['related-identifiers']
+       related_group.map do |hash|
+         {
+           "relation_type" =>  hash["relation-type-id"],
+           "related_identifier" => hash["related-identifier"],
+           "related_identifier_type" => 'DOI'
+         }
+       end
+
+     end
+
+     def auto_populated_fields
+       fields = []
+       fields << 'related_identifier' if related_identifier.present?
+       fields << 'title' if title.present?
+       fields << "published" if date_published_year.present?
+       fields << 'creator' if creator.present?
+       fields << 'abstract' if abstract.present?
+       fields << 'version' if version.present?
+       fields << 'license' if license.present?
+       "The following fields were auto-populated - #{fields.to_sentence}"
+     end
+
+     def data
+       {
+         'related_identifier_group': related_identifier,
+         "title": title, "published": date_published_year,
+         "abstract": abstract, "version": version,
+         "creator_group": creator, license: license,
+         "auto_populated": auto_populated_fields
+      }
+
+     end
+
+     private
+
+     def creator_without_seperated_names(data)
+       new_group = data.map {|hash| hash['literal']}
+       new_creator_group = []
+       new_group.each_with_index do |data, index|
+         new_data = data.split
+         creator_given_name = new_data.shift
+         creator_family_name = new_data.join(' ')
+         creator_position = index
+         creator_name_type = 'Personal'
+         hash = {'creator_given_name' =>  creator_given_name, 'creator_family_name' => creator_family_name,
+                 'creator_position' => creator_position, 'creator_name_type' => creator_name_type
+                 }
+          new_creator_group << hash
+       end
+       new_creator_group
+     end
+
+     def creator_with_seperated_names(data)
+       new_creator_group = []
+       data.each_with_index do |hash, index|
+         hash = {
+           "creator_given_name" =>  hash["given"],
+           "creator_family_name" => hash["family"],
+           "creator_name_type" => 'Personal',
+           "creator_position" => index
+         }
+         new_creator_group << hash
+       end
+       new_creator_group
+     end
+
+
+  end
+end

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -1,4 +1,9 @@
-<%# file copied here by Ubiquity from Hyrax so we can insert a new 'Notes' tab %>
+<%# file copied here by Ubiquity from Hyrax %>
+<!-- Button trigger modal -->
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#get-datacite-doi-metadata" >
+  <%= t('helpers.action.doi.new')%>
+</button>
+<% work_type = curation_concern.model_name.to_s %>
 
 <%# we will yield to content_for for each tab, e.g. :files_tab %>
 <% tabs ||= %w[metadata files relationships notes] # default tab order %>
@@ -66,3 +71,25 @@
       <%= render 'form_progress', f: f %>
     </div>
   </div>
+
+  <div class="modal doi fade" id="get-datacite-doi-metadata" tabindex="-1" role="dialog" aria-labelledby="get-datacite-doi-metadata-label">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <form class="get-datacite-doi-metadata-select">
+
+<!--      see https://github.com/samvera/hyrax/blob/v2.0.2/app/views/shared/_select_work_type_modal.html.erb -->
+
+          <div class="modal-body">
+            <%= work_type %>
+<!--            <input type="radio" name="payload_concern" value="<%#= work_type %>"-->
+<!--                   data-single="<%#= work_type.switch_to_new_work_path(route_set: main_app, params: params) %>">-->
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('hyrax.dashboard.heading_actions.close') %></button>
+            <input type="submit" class="btn btn-primary" value="<%= t('hyrax.dashboard.heading_actions.create_work') %>">
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -1,9 +1,4 @@
 <%# file copied here by Ubiquity from Hyrax %>
-<!-- Button trigger modal -->
-<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#get-datacite-doi-metadata" >
-  <%= t('helpers.action.doi.new')%>
-</button>
-<% work_type = curation_concern.model_name.to_s %>
 
 <%# we will yield to content_for for each tab, e.g. :files_tab %>
 <% tabs ||= %w[metadata files relationships notes] # default tab order %>
@@ -69,27 +64,6 @@
 
     <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
       <%= render 'form_progress', f: f %>
-    </div>
-  </div>
-
-  <div class="modal doi fade" id="get-datacite-doi-metadata" tabindex="-1" role="dialog" aria-labelledby="get-datacite-doi-metadata-label">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <form class="get-datacite-doi-metadata-select">
-
-<!--      see https://github.com/samvera/hyrax/blob/v2.0.2/app/views/shared/_select_work_type_modal.html.erb -->
-
-          <div class="modal-body">
-            <%= work_type %>
-<!--            <input type="radio" name="payload_concern" value="<%#= work_type %>"-->
-<!--                   data-single="<%#= work_type.switch_to_new_work_path(route_set: main_app, params: params) %>">-->
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('hyrax.dashboard.heading_actions.close') %></button>
-            <input type="submit" class="btn btn-primary" value="<%= t('hyrax.dashboard.heading_actions.create_work') %>">
-          </div>
-        </form>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/hyrax/base/new.html.erb
+++ b/app/views/hyrax/base/new.html.erb
@@ -1,0 +1,7 @@
+
+<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_header do %>
+  <h1><%= t("hyrax.works.create.header", type: curation_concern.human_readable_type) %></h1>
+<% end %>
+<%= render 'shared/ubiquity/datacite_doi' %>
+<%= render 'form' %>

--- a/app/views/hyrax/base/new.html.erb
+++ b/app/views/hyrax/base/new.html.erb
@@ -4,4 +4,5 @@
   <h1><%= t("hyrax.works.create.header", type: curation_concern.human_readable_type) %></h1>
 <% end %>
 <%= render 'shared/ubiquity/datacite_doi' %>
+
 <%= render 'form' %>

--- a/app/views/records/edit_fields/_abstract.html.erb
+++ b/app/views/records/edit_fields/_abstract.html.erb
@@ -1,5 +1,5 @@
 <% if f.object.multiple? key %>
-  <%= f.input :abstract, as: :multi_value, input_html: { rows: '14', type: 'textarea'}, required: f.object.required?(key) %>
+  <%= f.input :abstract, as: :multi_value, input_html: { rows: '14', type: 'textarea', class: 'ubiquity-abstract'}, required: f.object.required?(key) %>
 <% else %>
-  <%= f.input :abstract, as: :text, input_html: { rows: '14' }, required: f.object.required?(key) %>
+  <%= f.input :abstract, as: :text, input_html: { rows: '14', class: 'ubiquity-abstract' }, required: f.object.required?(key) %>
 <% end %>

--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -1,0 +1,6 @@
+<% license_service = Hyrax::LicenseService.new %>
+<%= f.input :license, as: :multi_value_select,
+    collection: license_service.select_active_options,
+    include_blank: true,
+    item_helper: license_service.method(:include_current_value),
+    input_html: { class: 'form-control ubiquity-license' } %>

--- a/app/views/shared/ubiquity/_datacite_doi.html.erb
+++ b/app/views/shared/ubiquity/_datacite_doi.html.erb
@@ -13,13 +13,20 @@
           <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>">
             <span aria-hidden="true">&times;</span></button>
           <p class="help-block ubiquity-modal-padding"><%= t('helpers.action.doi.placeholder') %></p>
-          <input class="form-control string optional" type="text" value="" name="<%= work_type.underscore %>[doi]" id="<%= work_type.underscore %>_doi">
-        </div>
+          <input class="ubiquity-datacite-value form-control string optional" type="text" value="" name="<%= work_type.underscore %>[doi]" id="<%= work_type.underscore %>_doi">
+
+         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('hyrax.dashboard.heading_actions.close') %></button>
+          <button type="button" class="btn btn-default ubiquity-datacite-fetch" data-dismiss="modal"><%= t('hyrax.dashboard.heading_actions.close') %></button>
           <input type="submit" class="btn btn-primary" value="<%= t('helpers.action.doi.submit') %>">
         </div>
       </div>
     </form>
   </div>
 </div>
+
+
+<h5 class="ubiquity-fields-populated" style="color:red;font-weight: 900;">  </h5>
+
+
+<%= render "shared/ubiquity/datacite_js"  %>

--- a/app/views/shared/ubiquity/_datacite_doi.html.erb
+++ b/app/views/shared/ubiquity/_datacite_doi.html.erb
@@ -13,7 +13,9 @@
           <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>">
             <span aria-hidden="true">&times;</span></button>
           <p class="help-block ubiquity-modal-padding"><%= t('helpers.action.doi.placeholder') %></p>
-          <input class="ubiquity-datacite-value form-control string optional" type="text" value="" name="<%= work_type.underscore %>[doi]" id="<%= work_type.underscore %>_doi">
+          <p class="help-block"> for example 10.5438/0012 or https://doi.org/10.5438/0012 or http://dx.doi.org/10.18154/RWTH-CONV-02056 </p>
+
+           <input class="ubiquity-datacite-value form-control string optional" type="text" value="" name="<%= work_type.underscore %>[doi]" id="<%= work_type.underscore %>_doi">
 
          </div>
         <div class="modal-footer">
@@ -27,6 +29,7 @@
 
 
 <h5 class="ubiquity-fields-populated" style="color:red;font-weight: 900;">  </h5>
+<h5 class="ubiquity-fields-populated-error" style="color:red;font-weight: 900;">  </h5>
 
 
 <%= render "shared/ubiquity/datacite_js"  %>

--- a/app/views/shared/ubiquity/_datacite_doi.html.erb
+++ b/app/views/shared/ubiquity/_datacite_doi.html.erb
@@ -1,0 +1,25 @@
+<%# called in hyrax/base/new.html.erb %>
+<% work_type = curation_concern.model_name.to_s %>
+<!-- Button trigger modal -->
+<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#get-datacite-doi-metadata" >
+  <%= t('helpers.action.doi.new')%>
+</button>
+<br/><br/>
+<div class="modal doi fade" id="get-datacite-doi-metadata" tabindex="-1" role="dialog" aria-labelledby="get-datacite-doi-metadata-label">
+  <div class="modal-dialog" role="document">
+    <form class="get-datacite-doi-metadata-select">
+      <div class="modal-content">
+        <div class="modal-body">
+          <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('hyrax.dashboard.heading_actions.close') %>">
+            <span aria-hidden="true">&times;</span></button>
+          <p class="help-block ubiquity-modal-padding"><%= t('helpers.action.doi.placeholder') %></p>
+          <input class="form-control string optional" type="text" value="" name="<%= work_type.underscore %>[doi]" id="<%= work_type.underscore %>_doi">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal"><%= t('hyrax.dashboard.heading_actions.close') %></button>
+          <input type="submit" class="btn btn-primary" value="<%= t('helpers.action.doi.submit') %>">
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/app/views/shared/ubiquity/_datacite_js.html.erb
+++ b/app/views/shared/ubiquity/_datacite_js.html.erb
@@ -12,8 +12,10 @@
 
       //
       var dataciteUrl = $(".ubiquity-datacite-value").val();
+      $(".ubiquity-fields-populated").hide()
+      $(".ubiquity-fields-populated-error").hide()
       //alert(dataciteUrl);
-        fetchDataciteData(dataciteUrl);
+      fetchDataciteData(dataciteUrl);
 
       event.preventDefault();
       $("#get-datacite-doi-metadata").modal('hide')
@@ -31,13 +33,21 @@
       data: {"url": url},
       success: function(result){
         //alert(result.title);
-        $(".ubiquity-title").val(result.data.title)
-        //populate dropdown
-        $('.ubiquity-date-published-year').val(result.data.published).change()
-        populateRelatedIdentifierValues(result.data.related_identifier_group)
-         populateCreatorValues(result.data.creator_group)
+        if (result.data.error  === undefined){
+          $(".ubiquity-title").val(result.data.title)
+          $('.ubiquity-abstract').val(result.data.abstract)
+          //populate dropdown
+          $('.ubiquity-date-published-year').val(result.data.published).change()
+          $('.ubiquity-license').val(result.data.license).change()
+          populateRelatedIdentifierValues(result.data.related_identifier_group)
+          populateCreatorValues(result.data.creator_group)
+          $(".ubiquity-fields-populated").html(result.data.auto_populated)
+          $(".ubiquity-fields-populated").show()
+        } else {
+          $(".ubiquity-fields-populated-error").html(result.data.error)
+          $(".ubiquity-fields-populated-error").show()
 
-        $(".ubiquity-fields-populated").html(result.data.auto_populated)
+        }
 
       },
       error: function(){
@@ -89,20 +99,21 @@
       div.children(".creator_family_name:last").val(value.creator_family_name)
       div.children('.creator_given_name').val(value.creator_given_name)
       div.children(".creator_position:last").val(value.creator_position)
-      div.children('.ubiquity_creator_name_type:last').val('Personal').change()
+      parent.children('.ubiquity_creator_name_type:last').val('Personal').change()
 
     }else {
-      parent = $(".ubiquity-meta-creator")
-      div = parent.children(".ubiquity_personal_fields:last")
+      parent = $(".ubiquity-meta-creator:last")
+      parentClone = parent.clone();
+      div = parentClone.children(".ubiquity_personal_fields:last")
 
-      cloned =  div.clone();
-      cloned.find('input').val('');
-      cloned.find('option').attr('selected', false);
-      div.after(cloned)
-      cloned.children(".creator_family_name:last").val(value.creator_family_name)
-      cloned.children('.creator_given_name:last').val(value.creator_given_name)
-      cloned.children(".creator_position:last").val(value.creator_position)
-      cloned.children('.ubiquity_creator_name_type:last').val('Personal').change()
+      //cloned =  div.clone();
+      parentClone.find('input').val('');
+      parentClone.find('option').attr('selected', false);
+      parent.after(parentClone)
+      parentClone.find(".creator_family_name:last").val(value.creator_family_name)
+      parentClone.find('.creator_given_name:last').val(value.creator_given_name)
+      parentClone.find(".creator_position:last").val(value.creator_position)
+      parentClone.find('.ubiquity_creator_name_type:last').val('Personal').change()
 
     }
   }

--- a/app/views/shared/ubiquity/_datacite_js.html.erb
+++ b/app/views/shared/ubiquity/_datacite_js.html.erb
@@ -1,0 +1,111 @@
+
+
+
+<script>
+  //$(".ubiquity-datacite-fetch").click()
+  //$(".get-datacite-doi-metadata-select").submit()
+  $(document).on("turbolinks:load", function(event){
+    event.preventDefault();
+
+    //return $("body").on("click", ".ubiquity-datacite-fetch", function(event){
+    return $("body").on("submit", ".get-datacite-doi-metadata-select", function(event){
+
+      //
+      var dataciteUrl = $(".ubiquity-datacite-value").val();
+      //alert(dataciteUrl);
+        fetchDataciteData(dataciteUrl);
+
+      event.preventDefault();
+      $("#get-datacite-doi-metadata").modal('hide')
+    }); //closes return
+
+  });
+
+  function fetchDataciteData(url){
+    var host = window.location.host;
+    var protocol = window.location.protocol;
+    var fullHost = protocol + '//' + host + '/available_ubiquity_titles/call_datasite';
+    $.ajax({
+      url: `${fullHost}`,
+      type: "POST",
+      data: {"url": url},
+      success: function(result){
+        //alert(result.title);
+        $(".ubiquity-title").val(result.data.title)
+        //populate dropdown
+        $('.ubiquity-date-published-year').val(result.data.published).change()
+        populateRelatedIdentifierValues(result.data.related_identifier_group)
+         populateCreatorValues(result.data.creator_group)
+
+        $(".ubiquity-fields-populated").html(result.data.auto_populated)
+
+      },
+      error: function(){
+      }
+      })
+    } //function
+
+  function populateRelatedIdentifierValues(relatedArray){
+    $.each(relatedArray, function(key, value){
+       addValues(key, value);
+    })
+  }
+
+  function addValues(key, value) {
+
+    if (key === 0) {
+      div = $(".ubiquity-meta-related-identifier");
+      //console.log(div)
+      div.children(".related_identifier").val(value.related_identifier)
+      $('.related_identifier_type').val(value.related_identifier_type).change()
+      div.children(".related_identifier_relation:last").val(value.relation_type).change()
+      //$(".related_identifier_relation").val(value.relation_type).change()
+    }else {
+      div = $(".ubiquity-meta-related-identifier:last")
+      cloned =  div.clone();
+      cloned.find('input').val('');
+      cloned.find('option').attr('selected', false);
+      div.after(cloned)
+      cloned.children(".related_identifier:last").val(value.related_identifier)
+      $('.related_identifier_type').val(value.related_identifier_type).change()
+      cloned.children(".related_identifier_relation:last").val(value.relation_type).change()
+    }
+  }
+
+
+  function populateCreatorValues(creatorArray){
+    $.each(creatorArray, function(key, value){
+       addCreatorValues(key, value);
+    })
+  }
+
+  function addCreatorValues(key, value) {
+    console.log('json.key', value.creator_family_name)
+
+    if (key === 0) {
+      parent = $(".ubiquity-meta-creator");
+      //console.log(div)
+      div = parent.children(".ubiquity_personal_fields:last")
+      div.children(".creator_family_name:last").val(value.creator_family_name)
+      div.children('.creator_given_name').val(value.creator_given_name)
+      div.children(".creator_position:last").val(value.creator_position)
+      div.children('.ubiquity_creator_name_type:last').val('Personal').change()
+
+    }else {
+      parent = $(".ubiquity-meta-creator")
+      div = parent.children(".ubiquity_personal_fields:last")
+
+      cloned =  div.clone();
+      cloned.find('input').val('');
+      cloned.find('option').attr('selected', false);
+      div.after(cloned)
+      cloned.children(".creator_family_name:last").val(value.creator_family_name)
+      cloned.children('.creator_given_name:last').val(value.creator_given_name)
+      cloned.children(".creator_position:last").val(value.creator_position)
+      cloned.children('.ubiquity_creator_name_type:last').val('Personal').change()
+
+    }
+  }
+
+
+</script>

--- a/app/views/shared/ubiquity/_date_published.html.erb
+++ b/app/views/shared/ubiquity/_date_published.html.erb
@@ -9,28 +9,28 @@
 <% if date_published.present? %>
   <%= select_tag "#{template}[date_published_group][][date_published_year]",
                  content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years_array), 'to_s', 'to_s', parse_date(date_published, 'year')),
-                 required: true, class: 'form-control ubiquity-date-input'
+                 required: true, class: 'form-control ubiquity-date-published-year ubiquity-date-input'
   %>
   <%= select_tag "#{template}[date_published_group][][date_published_month]",
                  content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months_array), 'to_s', 'to_s',parse_date(date_published, 'month')),
-                 {:class => 'form-control ubiquity-date-input'}
+                 {:class => 'form-control ubiquity-date-input ubiquity-date-published-month'}
   %>
   <%= select_tag "#{template}[date_published_group][][date_published_day]",
                  content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days_array), 'to_s', 'to_s', parse_date(date_published, 'day')),
-                 {:class => 'form-control ubiquity-date-input'}
+                 {:class => 'form-control ubiquity-date-input ubiquity-date-published-day'}
   %>
 <% else %>
   <%= select_tag "#{template}[date_published_group][][date_published_year]",
                  content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years_array), 'to_s', 'to_s'),
-                 required: true, class: 'form-control ubiquity-date-input'
+                 required: true, class: 'form-control ubiquity-date-published-year ubiquity-date-input'
   %>
   <%= select_tag "#{template}[date_published_group][][date_published_month]",
                  content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months_array), 'to_s', 'to_s'),
-                 {:class => 'form-control ubiquity-date-input'}
+                 {:class => 'form-control ubiquity-date-published-month ubiquity-date-input'}
   %>
   <%= select_tag "#{template}[date_published_group][][date_published_day]",
                  content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days_array), 'to_s', 'to_s'),
-                 {:class => 'form-control ubiquity-date-input'}
+                 {:class => 'form-control ubiquity-date-published-day ubiquity-date-input'}
   %>
 <% end %>
 <br/><br/><br/>

--- a/app/views/shared/ubiquity/creator/_new_form.html.erb
+++ b/app/views/shared/ubiquity/creator/_new_form.html.erb
@@ -52,7 +52,7 @@
     <label class="control-label multi_value optional" for="#{template}_creator_family_name">
       Creator family name</label>
     <%= text_field_tag  "#{template}[creator_group][][creator_family_name]", nil,
-                        class: "#{template}_creator_family_name form-control multi-text-field multi_value",
+                        class: "#{template}_creator_family_name creator_family_name form-control multi-text-field multi_value",
                         placeholder: 'Please enter the creator\'s last name/family name.',
                         name: "#{template}[creator_group][][creator_family_name]"
     %>
@@ -61,7 +61,7 @@
     <label class="control-label multi_value optional" for="#{template}_creator_given_name">
       Creator given name</label>
     <%= text_field_tag  "#{template}[creator_group][][creator_given_name]", nil,
-                        class: "#{template}_creator_given_name form-control multi-text-field multi_value",
+                        class: "#{template}_creator_given_name creator_given_name form-control multi-text-field multi_value",
                         placeholder: 'Please enter the creator\'s first name/given name.',
                         name: "#{template}[creator_group][][creator_given_name]"
     %>
@@ -75,7 +75,7 @@
   </span>  <!-- closes ubiquity_personal_fields -->
 
   <br>
-  <%= hidden_field_tag "#{template}[creator_group][][creator_position]", 1, class: 'ubiquity-creator-score'  %>
+  <%= hidden_field_tag "#{template}[creator_group][][creator_position]", 1, class: 'ubiquity-creator-score creator_position'  %>
 
   <a href="#" style="color:red;"  class=" remove_creator form-group " data-removeUbiquitycreator=".ubiquity-meta-creator">
     <span class="glyphicon glyphicon-remove"></span>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -30,3 +30,7 @@ en:
       fields:
         facet:
           library_of_congress_classification_sim: Library of Congress Classification
+  helpers:
+    action:
+      doi:
+        new: Fetch metadata from Datacite with DOI

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -34,3 +34,5 @@ en:
     action:
       doi:
         new: Fetch metadata from Datacite with DOI
+        submit: Fetch metadata
+        placeholder: Please add a DataCite DOI below

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :available_ubiquity_titles, only: [:check] do
       collection do
         post :check
+        post :call_datasite
       end
   end
 
@@ -85,6 +86,6 @@ Rails.application.routes.draw do
   require 'sidekiq/web'
   authenticate :user, lambda {|u| u.roles_name.include? 'admin' } do
     mount Sidekiq::Web => '/sidekiq'
-  end 
+  end
 
 end


### PR DESCRIPTION
Initial implementation.

1. It can create creators based on authors with no given name using this api:
    https://api.datacite.org/works/10.5438/0012

2. It can also create creators based on authors with given_name provided by the api as seen in this api:
    https://api.datacite.org/works/10.5438/0012

3. If those fields has multiple creators or related_identifier they will be created as such.

4. It can handle different url format. It has been tested with:
     https://api.datacite.org/works/10.5438/0012
     api.datacite.org/works/10.5438/0012
     /works/10.5438/0012
     works/10.5438/0012
     /10.5438/0012
    10.5438/0012
5. I have added fields to auto-populate title, creator, date_published and related_identifier.

Yet to be added javascript wise is version, license, abstract

![screenshot from 2018-11-30 14-13-24](https://user-images.githubusercontent.com/329514/49294877-1e9da400-f4ac-11e8-857e-f5affe506016.png)
