### PR TITLE
Rake task to auto create user and assign admin role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ public/assets/
 *.env
 *.pyc
 kiq.log
+
+/config/local_env.yml

--- a/lib/tasks/automatic_user.rake
+++ b/lib/tasks/automatic_user.rake
@@ -1,19 +1,21 @@
 
-#run with rake hyku:automatic_user:create['sandbox.repo-test.ubiquity.press']
+#run with:
+#bundle exec rake hyku:automatic_user:create
 
 namespace :hyku do
   namespace :automatic_user do
     desc "Create a user and make that user a superadmin"
-    task :create => :environment do 
-    #task :create, [:tenant_name] => :environment do |task, tenant|
-      #AccountElevator.switch!("#{tenant[:tenant_name]}")
+    task :create => :environment do
 
-      email = "tech_#{rand(252...41350)}@ubiquity.press.com"
+      email = ENV['DEFAULT_ADMIN_EMAIL']
+      password = ENV['DEFAULT_ADMIN_PASSWORD']
       puts "Creating user with email #{email}"
-      User.find_or_create_by(email: email) do |user|
+    
+      User.create! do |user|
          puts "assigning password to user"
-         user.password = 'ubiquity2197';
-         user.password_confirmation = 'ubiquity2197'
+         user.email = email
+         user.password = password;
+         user.password_confirmation = password
          puts "Granting user superadmin role"
          user.add_role(:superadmin)
      end

--- a/lib/tasks/automatic_user.rake
+++ b/lib/tasks/automatic_user.rake
@@ -1,0 +1,25 @@
+
+#run with rake hyku:automatic_user:create['sandbox.repo-test.ubiquity.press']
+
+namespace :hyku do
+  namespace :automatic_user do
+    desc "Create a user and make that user a superadmin"
+    task :create => :environment do 
+    #task :create, [:tenant_name] => :environment do |task, tenant|
+      #AccountElevator.switch!("#{tenant[:tenant_name]}")
+
+      email = "tech_#{rand(252...41350)}@ubiquity.press.com"
+      puts "Creating user with email #{email}"
+      User.find_or_create_by(email: email) do |user|
+         puts "assigning password to user"
+         user.password = 'ubiquity2197';
+         user.password_confirmation = 'ubiquity2197'
+         puts "Granting user superadmin role"
+         user.add_role(:superadmin)
+     end
+
+     puts "User successfully created"
+    end
+
+  end
+end


### PR DESCRIPTION
Rake task to auto create user and assign admin role

You can't run it  locally though,  without following the instructions below

you will need to create a file in config, that is config/local_env.yml containing the following

    DEFAULT_ADMIN_EMAIL: defautl_email1@ubiquitypress.com
    DEFAULT_ADMIN_PASSWORD: ubiquity1

This file is ignored in .gitignore as it is just to test that environment variables are picked in the code.

Next in config/application.rb add:

    config.before_configuration do
       env_file = File.join(Rails.root, 'config', 'local_env.yml')
       YAML.load(File.open(env_file)).each do |key, value|
           ENV[key.to_s] = value
      end if File.exists?(env_file)
    end

The you can run it with :

    bundle exec rake hyku:automatic_user:create 