### PR TITLE
rescue from tenant not found and redirect to splash shared layer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,8 +25,9 @@ class ApplicationController < ActionController::Base
 
   before_action :set_raven_context
 
+  #UbiquityPress is temporarily using redirect_to to replace raise ActionController::RoutingError, 'Not Found' in rescue_from block
   rescue_from Apartment::TenantNotFound do
-    raise ActionController::RoutingError, 'Not Found'
+    redirect_to "#{request.protocol}#{Account.admin_host}:#{request.port}/"
   end
 
   private


### PR DESCRIPTION
rescue from tenant not found and redirect to splash shared layer

Steps to test it:
Start the Hyku app, then try to navigate to a non-existent tenant, it should take you back to the splash page where you can click on any of the tenants listed there to redirect to where you want.