### PR TITLE
Icon for zip files across views

### DIFF
--- a/app/assets/stylesheets/ubiquity.scss
+++ b/app/assets/stylesheets/ubiquity.scss
@@ -168,3 +168,21 @@ h4, .homepage-nav-tabs {
   font-size: 1.2em;
   font-weight: 400;
 }
+
+.grey-zip-icon {
+  color: $gray;
+}
+
+.zip-thumbnail-homepage {
+  padding-left: 115px;
+  position: relative;
+  line-height: 60px;
+}
+.zip-thumbnail-homepage:before {
+  position: absolute;
+  font-family: 'FontAwesome';
+  left: 30px;
+  content: "\f1c6";
+  color: $gray;
+  font-size: 3em;
+}

--- a/app/views/hyrax/dashboard/collections/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_works.html.erb
@@ -1,11 +1,10 @@
-<%# Copied from Hyrax, this file may be remove once integrated with Hyrax v2.1 %>
-<%# https://github.com/samvera/hyrax/blob/v2.1.0/app/views/hyrax/dashboard/works/_list_works.html.erb %>
-
 <tr id="document_<%= document.id %>">
+
   <td>
-    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%=t("hyrax.dashboard.my.sr.batch_checkbox")%></label>
     <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
   </td>
+
   <td>
     <div class='media'>
 
@@ -29,11 +28,12 @@
     </div>
   </td>
 
-  <td class='text-center'><%= document.date_uploaded %></td>
-  <td class='workflow-state'><%= presenter.workflow.state_label %></td>
-  <td class='text-center'><%= render_visibility_link document %></td>
-
+  <td class="date"><%= document.date_uploaded %></td>
   <td class='text-center'>
+    <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>"></span></td>
+  <td><%= render_visibility_link document %></td>
+
+  <td>
     <%= render 'work_action_menu', document: document %>
   </td>
 </tr>

--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -11,7 +11,11 @@
               <!-- if condition added by ubiquity to display image or empty border but not default icon-->
               <% if collection.thumbnail_id %>
                 <%= link_to [hyrax, collection], class: 'media-left', 'aria-hidden' => true do %>
-                  <%= render_thumbnail_tag collection, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+                  <% if FileSet.find(collection.thumbnail_id).format_label.first == 'ZIP Format' %>
+                    <span class="zip-thumbnail-homepage hidden-xs"></span>
+                  <% else %>
+                    <%= render_thumbnail_tag collection, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+                  <% end %>
                 <% end %>
               <% else %>
                 <%= link_to "", class: 'media-left', 'aria-hidden' => true do %>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -5,7 +5,11 @@
 <div class="featured-fields" >
   <%= link_to [main_app, featured] do %>
     <div class="featured-item-thumbnail">
-      <%= render_related_img(featured_doc) %>
+      <% if featured_doc.thumbnail_id && FileSet.find(featured_doc.thumbnail_id).format_label.first == 'ZIP Format' %>
+        <span class="fa fa-file-archive-o fa-5x grey-zip-icon"></span>
+      <% else %>
+        <%= render_related_img(featured_doc) %>
+      <% end %>
     </div>
     <div class="featured-item homepage-field-title">
       <%= featured.title.first %>

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -1,11 +1,10 @@
-<%# Copied from Hyrax, this file may be remove once integrated with Hyrax v2.1 %>
-<%# https://github.com/samvera/hyrax/blob/v2.1.0/app/views/hyrax/dashboard/works/_list_works.html.erb %>
-
 <tr id="document_<%= document.id %>">
+
   <td>
-    <label for="batch_document_<%= document.id %>" class="sr-only"><%= t("hyrax.dashboard.my.sr.batch_checkbox") %></label>
+    <label for="batch_document_<%= document.id %>" class="sr-only"><%=t("hyrax.dashboard.my.sr.batch_checkbox")%></label>
     <%= render 'hyrax/batch_select/add_button', document: document %>&nbsp;
   </td>
+
   <td>
     <div class='media'>
 
@@ -29,11 +28,12 @@
     </div>
   </td>
 
-  <td class='text-center'><%= document.date_uploaded %></td>
-  <td class='workflow-state'><%= presenter.workflow.state_label %></td>
-  <td class='text-center'><%= render_visibility_link document %></td>
-
+  <td class="date"><%= document.date_uploaded %></td>
   <td class='text-center'>
+    <span class="fa <%= current_user.trophies.where(work_id: document.id).exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>"></span></td>
+  <td><%= render_visibility_link document %></td>
+
+  <td>
     <%= render 'work_action_menu', document: document %>
   </td>
 </tr>

--- a/app/views/shared/ubiquity/_thumbnail.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail.html.erb
@@ -1,0 +1,7 @@
+<%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+  <% if document.thumbnail_id && FileSet.find(document.thumbnail_id).format_label.first == 'ZIP Format' %>
+    <span class="fa fa-file-archive-o fa-5x grey-zip-icon hidden-xs file_listing_thumbnail"></span>
+  <% else %>
+    <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+  <% end %>
+<% end %>

--- a/app/views/shared/ubiquity/collections/_list_collections.html.erb
+++ b/app/views/shared/ubiquity/collections/_list_collections.html.erb
@@ -13,7 +13,11 @@
     <div class="media">
       <!-- This if condiftion was added by UbiquityPress -->
       <% if document.thumbnail_id %>
-        <span  class="collection-icon-small pull-left"><%= render_thumbnail_tag document, :style => 'width:18px' %></span>
+        <% if FileSet.find(document.thumbnail_id).format_label.first == 'ZIP Format' %>
+          <span class="fa fa-file-archive-o grey-zip-icon pull-left collection-icon-small"></span>
+        <% else %>
+          <span  class="collection-icon-small pull-left"><%= render_thumbnail_tag document, :style => 'width:18px' %></span>
+        <% end %>
       <% else %>
           <!-- this was the default in hyrax -->
           <span class="<%# Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small pull-left"></span>

--- a/app/views/shared/ubiquity/collections/_show_document_list_row.html.erb
+++ b/app/views/shared/ubiquity/collections/_show_document_list_row.html.erb
@@ -15,9 +15,7 @@
   <td>
     <div class="media">
       <% if  document.thumbnail_id %>
-        <%= link_to [main_app, document], class: "media-left" do %>
-          <%= render_thumbnail_tag document, { class: "hidden-xs file_listing_thumbnail" }, { suppress_link: true } %>
-        <% end %>
+        <%= render 'shared/ubiquity/thumbnail', document: document %>
       <% else %>
         <%= link_to "", class: 'media-left', 'aria-hidden' => true do %>
           <span class="media-left hidden-xs file_listing_thumbnail" style="height:55px;width:50px;padding-left: 60px;" ></span>

--- a/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
+++ b/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
@@ -3,7 +3,11 @@
 
 <% if document.thumbnail_id %>
   <div class="list-thumbnail">
-    <%= render_thumbnail_tag document, :style => "width:150px" %>
+    <% if document.thumbnail_id && FileSet.find(document.thumbnail_id).format_label.first == 'ZIP Format' %>
+      <span class="fa fa-file-archive-o fa-5x grey-zip-icon"></span>
+    <% else %>
+      <%= render_thumbnail_tag document, :style => "width:150px" %>
+    <% end %>
   </div>
 <% else %>
   <div class="list-thumbnail col-md-2">

--- a/app/views/shared/ubiquity/works/_member.html.erb
+++ b/app/views/shared/ubiquity/works/_member.html.erb
@@ -2,8 +2,13 @@
 
 <tr class="<%= dom_class(member) %> attributes">
   <td class="thumbnail">
-    <%= render_thumbnail_tag member %>
-  </td>
+    <% check_zip = File.extname(member.link_name) %>
+    <% if check_zip == ".zip" %>
+      <span class="fa fa-file-archive-o fa-5x grey-zip-icon"></span>
+    <% else %>
+      <%= render_thumbnail_tag member %>
+    <% end %>
+ </td>
   <td class="attribute filename"><%= link_to(member.link_name, contextual_path(member, @presenter)) %></td>
   <td class="attribute date_uploaded"><%= member.try(:date_uploaded) %></td>
   <td class="attribute permission">


### PR DESCRIPTION
Trello #[367](https://trello.com/c/PXF3QKlL)

Show generic zip icon from fontawesome in several views. Before changes, the app displays a link instead of a thumbnail:

![screenshot from 2018-12-17 12-23-02](https://user-images.githubusercontent.com/26539307/50086955-9aab2200-01f6-11e9-88f0-a9fcf75dc543.png)

Changes:
![screenshot from 2018-12-17 12-25-17](https://user-images.githubusercontent.com/26539307/50087092-d6de8280-01f6-11e9-90c5-f9e13e039d10.png)
