### PR TITLE
avoid database query directly from view files

### DIFF
--- a/app/views/hyrax/homepage/_explore_collections.html.erb
+++ b/app/views/hyrax/homepage/_explore_collections.html.erb
@@ -11,7 +11,7 @@
               <!-- if condition added by ubiquity to display image or empty border but not default icon-->
               <% if collection.thumbnail_id %>
                 <%= link_to [hyrax, collection], class: 'media-left', 'aria-hidden' => true do %>
-                  <% if FileSet.find(collection.thumbnail_id).format_label.first == 'ZIP Format' %>
+                  <% if File.extname(collection.thumbnail_path).blank? %>
                     <span class="zip-thumbnail-homepage hidden-xs"></span>
                   <% else %>
                     <%= render_thumbnail_tag collection, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -5,7 +5,7 @@
 <div class="featured-fields" >
   <%= link_to [main_app, featured] do %>
     <div class="featured-item-thumbnail">
-      <% if featured_doc.thumbnail_id && FileSet.find(featured_doc.thumbnail_id).format_label.first == 'ZIP Format' %>
+      <% if featured_doc.thumbnail_id && File.extname(featured_doc.thumbnail_path).blank? %>
         <span class="fa fa-file-archive-o fa-5x grey-zip-icon"></span>
       <% else %>
         <%= render_related_img(featured_doc) %>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,29 +1,32 @@
 <%# Fix to not display default image icon. This file was copied from
   https://github.com/samvera/hyrax/blob/37a1c370cd05a7ed0a8ca2ad453bc15eb812f132/app/views/hyrax/homepage/_recent_document.html.erb
  %>
-<tr>
-  <td>
-    <div class="media">
-      <!-- if condition added by ubiquity to ensure default thumbnail is not displayed-->
-      <% if recent_document.thumbnail_id %>
-        <%= link_to [main_app, recent_document], class: 'media-left', 'aria-hidden' => true do %>
-          <% if FileSet.find(recent_document.thumbnail_id).format_label.first == 'ZIP Format' %>
-            <span class="zip-thumbnail-homepage hidden-xs"></span>
-          <% else %>
-            <%= render_thumbnail_tag recent_document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
-          <% end %>
-        <% end %>
-      <% else %>
-        <%= link_to "", class: 'media-left', 'aria-hidden' => true do %>
-          <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>
-        <% end %>
-      <% end %>
-      <div class="media-body">
-        <h5 class="homepage-field-title">
-          <span class="sr-only">Title</span><%= link_to (recent_document.to_s), [main_app, recent_document] %>
-        </h5>
-        <span class="sr-only">Creator</span><%= link_to_facet_list(recent_document.creator_search, 'creator_search').html_safe %>
-      </div>
-    </div>
-  </td>
-</tr>
+ <%# Fix to not display default image icon. This file was copied from
+   https://github.com/samvera/hyrax/blob/37a1c370cd05a7ed0a8ca2ad453bc15eb812f132/app/views/hyrax/homepage/_recent_document.html.erb
+  %>
+ <tr>
+   <td>
+     <div class="media">
+       <!-- if condition added by ubiquity to ensure default thumbnail is not displayed-->
+       <% if recent_document.thumbnail_id %>
+         <%= link_to [main_app, recent_document], class: 'media-left', 'aria-hidden' => true do %>
+           <% if File.extname(recent_document.thumbnail_path).blank? %>
+             <span class="zip-thumbnail-homepage hidden-xs"></span>
+           <% else %>
+             <%= render_thumbnail_tag recent_document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+           <% end %>
+         <% end %>
+       <% else %>
+         <%= link_to "", class: 'media-left', 'aria-hidden' => true do %>
+           <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>
+         <% end %>
+       <% end %>
+       <div class="media-body">
+         <h5 class="homepage-field-title">
+           <span class="sr-only">Title</span><%= link_to (recent_document.to_s), [main_app, recent_document] %>
+         </h5>
+         <span class="sr-only">Creator</span><%= link_to_facet_list(recent_document.creator_search, 'creator_search').html_safe %>
+       </div>
+     </div>
+   </td>
+ </tr>

--- a/app/views/shared/ubiquity/_thumbnail.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail.html.erb
@@ -1,5 +1,5 @@
 <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
-  <% if document.thumbnail_id && FileSet.find(document.thumbnail_id).format_label.first == 'ZIP Format' %>
+  <% if document.thumbnail_id && File.extname(document.thumbnail_path).blank? %>
     <span class="fa fa-file-archive-o fa-5x grey-zip-icon hidden-xs file_listing_thumbnail"></span>
   <% else %>
     <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>

--- a/app/views/shared/ubiquity/collections/_list_collections.html.erb
+++ b/app/views/shared/ubiquity/collections/_list_collections.html.erb
@@ -13,7 +13,7 @@
     <div class="media">
       <!-- This if condiftion was added by UbiquityPress -->
       <% if document.thumbnail_id %>
-        <% if FileSet.find(document.thumbnail_id).format_label.first == 'ZIP Format' %>
+        <% if File.extname(document.thumbnail_path).blank? %>
           <span class="fa fa-file-archive-o grey-zip-icon pull-left collection-icon-small"></span>
         <% else %>
           <span  class="collection-icon-small pull-left"><%= render_thumbnail_tag document, :style => 'width:18px' %></span>
@@ -40,7 +40,7 @@
   <td class="text-center">
     <%= render_visibility_link(document) %>
   </td>
-  
+
    <!-- Added by UbiquityPress to enable us share same partial from dashboard when we click
     collections then 'All collections or Your collections' Tab-->
    <td class="text-center">

--- a/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
+++ b/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
@@ -3,7 +3,7 @@
 
 <% if document.thumbnail_id %>
   <div class="list-thumbnail">
-    <% if document.thumbnail_id && FileSet.find(document.thumbnail_id).format_label.first == 'ZIP Format' %>
+    <% if document.thumbnail_id && File.extname(document.thumbnail_path).blank? %>
       <span class="fa fa-file-archive-o fa-5x grey-zip-icon"></span>
     <% else %>
       <%= render_thumbnail_tag document, :style => "width:150px" %>


### PR DESCRIPTION
The information we need to check if the file is a zip or not is already available in the views hence no need for the query.
If you run into this. Thanks for the work together.