### PR TITLE
Add additional years to date pickers for exhibition_date view

### DIFF
--- a/app/views/shared/ubiquity/related_exhibition_date/_related_exhibition_date.html.erb
+++ b/app/views/shared/ubiquity/related_exhibition_date/_related_exhibition_date.html.erb
@@ -1,59 +1,29 @@
 <%# see app/views/records/edit_fields/_date_published.html.erb %>
 <% template = @curation_concern.class.to_s.underscore %>
 
-<% if related_exhibition_date.present? %>
-  <% related_exhibition_date.each do |date| %>
-    
-    <div class="ubiquity-meta-related-exhibition-date">
-      <label class="control-label multi_value optional" for="<% template %>_related_exhibition_date">Related exhibition date</label>
-      <p class="help-block"><%= t('simple_form.hints.defaults.related_exhibition_date') %></p>
-      <%= select_tag "#{template}[related_exhibition_date_group][][related_exhibition_date_year]",
-                 content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years_array), 'to_s', 'to_s', parse_date(date, 'year')),
-                 class: 'form-control ubiquity-date-input'
-      %>
-      <%= select_tag "#{template}[related_exhibition_date_group][][related_exhibition_date_month]",
-                 content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months_array), 'to_s', 'to_s', parse_date(date, 'month')),
-                 {:class => 'form-control ubiquity-date-input'}
-      %>
-      <%= select_tag "#{template}[related_exhibition_date_group][][related_exhibition_date_day]",
-                 content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days_array), 'to_s', 'to_s', parse_date(date, 'day')),
-                 {:class => 'form-control ubiquity-date-input'}
-      %>
-      <br/><br/>
-      <a href="#" style="color:red;" class="remove_related_exhibition_date form-group" data-removeUbiquityRelatedExhibitionDate=".ubiquity-meta-related-exhibition-date">
-        <span class="glyphicon glyphicon-remove"></span>
-        <span class="controls-remove-text">Remove</span>
-      </a>
-      |
-      <a href="#" class="add_related_exhibition_date" data-addUbiquityRelatedExhibitionDate=".ubiquity-meta-related-exhibition-date">Add
-        another </a>
-      <br/><br/><br/>
-    </div>
-  <% end %>
-<% else %>
+
+<% related_exhibition_date.each do |date| %>
   <div class="ubiquity-meta-related-exhibition-date">
     <label class="control-label multi_value optional" for="<% template %>_related_exhibition_date">Related exhibition date</label>
     <p class="help-block"><%= t('simple_form.hints.defaults.related_exhibition_date') %></p>
-    <%= select_tag "#{template}[related_exhibition_date_group][][related_exhibition_date_year]",
-                 content_tag(:option, 'select year', :value => "") + options_from_collection_for_select((years_array), 'to_s', 'to_s'),
-                 class: 'form-control ubiquity-date-input'
-    %>
-    <%= select_tag "#{template}[related_exhibition_date_group][][related_exhibition_date_month]",
-                 content_tag(:option, 'select month if available', :value => "") + options_from_collection_for_select((months_array), 'to_s', 'to_s'),
-                 {:class => 'form-control ubiquity-date-input'}
-    %>
-    <%= select_tag "#{template}[related_exhibition_date_group][][related_exhibition_date_day]",
-                 content_tag(:option, 'select day if available', :value => "") + options_from_collection_for_select((days_array), 'to_s', 'to_s'),
-                 {:class => 'form-control ubiquity-date-input'}
-    %>
+
+    <%= select_year(parse_date(date, 'year').to_i, {start_year: (Date.today.year + 6), end_year: (Date.today.year - 159), prompt: "Select year"}, {name: "#{template}[related_exhibition_date_group][]related_exhibition_date_year]", class: 'form-control ubiquity-date-input'} ) %>
+
+    <%= select_month(parse_date(date, 'month').to_i, { use_two_digit_numbers: true,
+                                                         prompt: 'select month if available'},   {name:  "#{template}[related_exhibition_date_group][][related_exhibition_date_month]", :class => 'form-control ubiquity-date-input'}) %>
+    <%= select_day(parse_date(date, 'day').to_i, { use_two_digit_numbers: true,
+                                                     prompt: 'select day if available'},   {name:  "#{template}[related_exhibition_date_group][][related_exhibition_date_day]", :class => 'form-control ubiquity-date-input'}) %>
+
+
     <br/><br/>
     <a href="#" style="color:red;" class="remove_related_exhibition_date form-group" data-removeUbiquityRelatedExhibitionDate=".ubiquity-meta-related-exhibition-date">
       <span class="glyphicon glyphicon-remove"></span>
       <span class="controls-remove-text">Remove</span>
     </a>
-    |
+      |
     <a href="#" class="add_related_exhibition_date" data-addUbiquityRelatedExhibitionDate=".ubiquity-meta-related-exhibition-date">Add
       another </a>
     <br/><br/><br/>
   </div>
 <% end %>
+


### PR DESCRIPTION
Additional fix to: https://trello.com/c/fjHyMQ18/407-date-pickers-should-include-2019-and-2020-as-options
