### PR TITLE
Each creators separted by semicolon and show as one liner

### DIFF
--- a/app/helpers/multiple_metadata_fields_helper.rb
+++ b/app/helpers/multiple_metadata_fields_helper.rb
@@ -126,6 +126,17 @@ module MultipleMetadataFieldsHelper
     end
   end
 
+  def extract_creator_names_for_homepage(record)
+    if record.present?
+      data  = JSON.parse(record.creator.first)
+      creator_names = []
+      data.each do |hash|
+        add_comma_if_both_names_present(hash, creator_names)
+      end
+      creator_names
+    end
+  end
+
   def get_model(presenter_record, model_class, field, multipart_sort_field_name = nil)
     #model ||= model_class.constantize.new
 
@@ -159,6 +170,15 @@ module MultipleMetadataFieldsHelper
     if (key.present? && array_of_hash.first.class == Hash)
       #allows the sort to function even if the value of a hash is nil
       array_of_hash.sort_by{ |hash| hash[key].to_i}
+    end
+  end
+
+  def add_comma_if_both_names_present(hash, creator_names)
+    if  (hash['creator_given_name'].present? && hash['creator_family_name'].present? )
+      add_comma = ','
+      creator_names <<  "#{hash['creator_family_name']}#{add_comma} #{ hash['creator_given_name']}"
+    else
+      creator_names <<  "#{hash['creator_family_name']}#{add_comma}#{ hash['creator_given_name']}"
     end
   end
 

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -4,7 +4,6 @@
  <%# Fix to not display default image icon. This file was copied from
    https://github.com/samvera/hyrax/blob/37a1c370cd05a7ed0a8ca2ad453bc15eb812f132/app/views/hyrax/homepage/_recent_document.html.erb
   %>
-
  <tr>
    <td>
      <div class="media">
@@ -22,7 +21,7 @@
          <h5 class="homepage-field-title">
            <span class="sr-only">Title</span><%= link_to (recent_document.to_s), [main_app, recent_document] %>
          </h5>
-         <span class="sr-only">Creator</span><%= link_to_facet_list(recent_document.creator_search, 'creator_search').html_safe %>
+         <span class="sr-only">Creator</span><%= link_to_facet_list(extract_creator_names_for_homepage(recent_document), 'creator_search', '', '; ').html_safe %>
        </div>
      </div>
    </td>

--- a/app/views/shared/ubiquity/search_display/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/search_display/_show_array_hash.html.erb
@@ -1,46 +1,17 @@
+<span style="display:inline;float:left;">
 <% array_of_hash.each do |hash| %>
-  <span itemprop='<%= "#{attr_name}" %>' style="float:left">
+  <span itemprop='<%= "#{attr_name}" %>' style="float:left;">
     <% if hash["#{attr_name}_organization_name"] %>
       <%= hash["#{attr_name}_organization_name"] %>
     <% end %>
     <% if hash["#{attr_name}_family_name"]  %>
       <% last_name = hash["#{attr_name}_family_name"] %>
       <% last_name << ',' if display_comma?(hash.keys, ["#{attr_name}_family_name", "#{attr_name}_given_name"]) %>
-      <%= last_name %>
+      <%= last_name %><% if hash["#{attr_name}_given_name"] %> <%= hash["#{attr_name}_given_name"] %><% end %><span>; &nbsp;</span>
     <% end %>
-    <% if hash["#{attr_name}_given_name"] %>
-      <%= hash["#{attr_name}_given_name"] %>
-    <% end %>
+
   </span>
-  <span itemprop='<%= "#{attr_name}" %>'>
-    <% if display_paren?(hash.keys, ["#{attr_name}_orcid", "#{attr_name}_isni", "#{attr_name}_type"]) %>
-      <span style="float:left" > &nbsp;(</span>
 
-      <span style="float:left">
-        <% if ("#{attr_name}" == 'contributor') && hash['contributor_type'].present? %>
-          <%= hash['contributor_type'] %><% if display_comma?(hash.keys, ["contributor_type", "contributor_orcid", "contributor_isni"]) %>,&nbsp;<% end %>
-        <% end %>
 
-      </span>
-        <% if hash["#{attr_name}_orcid"].present? %>
-          <% orcid_id = hash["#{attr_name}_orcid"] %>
-          <a href='<%= render_isni_or_orcid_url("#{orcid_id}", "orcid") %>'  target="_blank">
-            <img src="https://s3-eu-west-1.amazonaws.com/service-hyku-oar-importer/orcid_16x16.png" alt="ORCID"  height="16" width="16" class="img-responsive"  style="float:left"  >
-          </a>
-        <% end %>
-
-        <% if add_image_space?(hash.keys) %>
-          <span style="float:left" >&nbsp;</span>
-        <% end %>
-
-        <% if hash["#{attr_name}_isni"].present? %>
-          <% isni_id = hash["#{attr_name}_isni"] %>
-          <a href='<%= render_isni_or_orcid_url("#{isni_id}", "isni") %>'  target="_blank">
-            <img src="https://s3-eu-west-1.amazonaws.com/service-hyku-oar-importer/logo_xml_isni-16.gif" alt="ISNI"  height="16" width="44" class="img-responsive" style="float:left"  >
-          </a>
-        <% end %>
-      <span >)<span>
-    <% end %>
-  </span>
-  <br/>
 <% end %>
+  </span>


### PR DESCRIPTION
Resolved: https://trello.com/c/COKVGZGO/405-05-on-homepage-and-search-separate-creators-contributors-editors-with-a-semi-colon-instead-of-a-comma-also-on-search-run-all-cr
