### PR TITLE
Add institution as extra term for batch editing

### DIFF
--- a/app/forms/ubiquity/additional_batch_edit.rb
+++ b/app/forms/ubiquity/additional_batch_edit.rb
@@ -1,0 +1,57 @@
+# Defined in https://github.com/samvera/hyrax/blob/v2.0.2/app/forms/hyrax/forms/batch_edit_form.rb
+# In order to Add more fields to batch edit
+  module Ubiquity
+    #to do :version, not to be added until investigation is done as to why it is throwing an error
+    module AdditionalBatchEdit
+
+      new_terms = [:institution]
+     Hyrax::Forms::BatchEditForm.terms += new_terms
+      Hyrax::Forms::BatchEditForm.terms -= [:creator, :contributor]
+
+#   # override this method if you need to initialize more complex RDF assertions (b-nodes)
+#    # @return [Hash<String, Array>] the list of unique values per field
+   private
+    def initialize_combined_fields
+      # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
+      batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
+        work = ActiveFedora::Base.find(doc_id)
+        terms.each do |field|
+          combined_attributes[field] ||= []
+          work_field = work.try(field).try(:to_a) if work.try(field).present?
+          if  work_field.present?
+            combined_attributes[field] = (combined_attributes[field] +  work_field ).uniq
+          end
+       end
+       names << work.to_s
+      end
+    end
+
+   end
+ end
+
+
+# Hyrax::Forms::BatchEditForm.class_eval do
+#    new_terms = [:institution, :title, :doi, :rights_statement, :editor]
+#    self.terms += new_terms
+#
+#    # override this method if you need to initialize more complex RDF assertions (b-nodes)
+#    # @return [Hash<String, Array>] the list of unique values per field
+#    def initialize_combined_fields
+#      # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
+#      batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
+#        work = ActiveFedora::Base.find(doc_id)
+#        terms.each do |field|
+#
+#          combined_attributes[field] ||= []
+#          work_field = work.try(field).to_a if work.try(field).present?
+#          #combined_attributes[field] = (combined_attributes[field] +  work.try(:field).try(:to_a) ).uniq
+#          if  work_field.present?
+#            combined_attributes[field] = (combined_attributes[field] +  work_field ).uniq
+#          end
+#        end
+#        names << work.to_s
+#      end
+#    end
+#
+#  end
+

--- a/app/views/records/edit_fields/_alternate_identifier.html.erb
+++ b/app/views/records/edit_fields/_alternate_identifier.html.erb
@@ -1,6 +1,13 @@
-<% if curation_concern.new_record? %>
-  <%= render "shared/ubiquity/alternate_identifier/new_form" %>
+
+  <% if  f.object.model.new_record? %>
+  <%= render "shared/ubiquity/alternate_identifier/new_form", f: f %>
 <% else %>
-  <%= render "shared/ubiquity/alternate_identifier/edit_form", curation_concern: curation_concern %>
+    <% array_of_hash = get_model(f.object.model.alternate_identifier, f.object.model.class, 'alternate_identifier') %>
+    <!--
+  Ensures the edit form still renders the related_identifier fields when it is nil instead of an array of hash
+  -->
+    <% array_of_hash =  array_of_hash || [{}] %>
+
+    <%= render "shared/ubiquity/alternate_identifier/edit_form", f: f, array_of_hash: array_of_hash  %>
 <% end %>
 <%= render "shared/ubiquity/alternate_identifier/alternate_identifier_js" %>

--- a/app/views/records/edit_fields/_editor.html.erb
+++ b/app/views/records/edit_fields/_editor.html.erb
@@ -1,8 +1,8 @@
 
-<% if  curation_concern.new_record? %>
-  <%= render "shared/ubiquity/editor/new_form" %>
+<% if  f.object.model.new_record? %>
+  <%= render "shared/ubiquity/editor/new_form", f: f %>
 <% else %>
-  <% array_hash = get_model(curation_concern.editor, curation_concern.class, 'editor', 'editor_position') %>
+  <% array_hash = get_model(f.object.model.editor, f.object.model.class, 'editor', 'editor_position') %>
 
   <!--
   Clicking edit button returns an error it is something other than an array of hash
@@ -12,7 +12,9 @@
   The line below fixes that
   -->
   <% array_of_hash = array_hash || [{}] %>
-  <%= render "shared/ubiquity/editor/edit_array_hash_form", curation_concern: curation_concern, f: f, array_of_hash: array_of_hash %>
+  <%# render "shared/ubiquity/editor/edit_array_hash_form", curation_concern: curation_concern, f: f, array_of_hash: array_of_hash %>
+  <%= render "shared/ubiquity/editor/edit_array_hash_form", f: f, array_of_hash: array_of_hash %>
+
 <% end %>
 
 <%= render "shared/ubiquity/editor/editor_js" %>

--- a/app/views/records/edit_fields/_related_identifier.html.erb
+++ b/app/views/records/edit_fields/_related_identifier.html.erb
@@ -1,6 +1,14 @@
-<% if curation_concern.new_record? %>
-  <%= render "shared/ubiquity/related_identifier/new_form" %>
+<% if  f.object.model.new_record?  %>
+  <%= render "shared/ubiquity/related_identifier/new_form", f: f %>
 <% else %>
-  <%= render "shared/ubiquity/related_identifier/edit_form", curation_concern: curation_concern %>
+  <% array_of_hash = get_model(f.object.model.related_identifier, f.object.model.class,  'related_identifier') %>
+
+  <!--
+  Ensures the edit form still renders the related_identifier fields when it is nil instead of an array of hash
+  -->
+  <% array_of_hash =  array_of_hash || [{}] %>
+  <%= render "shared/ubiquity/related_identifier/edit_form", f: f, array_of_hash: array_of_hash  %>
 <% end %>
 <%= render "shared/ubiquity/related_identifier/related_identifier_js" %>
+
+

--- a/app/views/shared/ubiquity/alternate_identifier/_edit_form.html.erb
+++ b/app/views/shared/ubiquity/alternate_identifier/_edit_form.html.erb
@@ -1,16 +1,5 @@
-<% array_of_hash = get_model(curation_concern.class, curation_concern.id, 'alternate_identifier') %>
-
-<!--
-Ensures the edit form still renders the related_identifier fields when it is nil instead of an array of hash
--->
-<% array_of_hash =  array_of_hash || [{}] %>
 
 <% if (array_of_hash.class == Array && array_of_hash.first.class == Hash)  %>
   <%= render "shared/ubiquity/alternate_identifier/edit_array_hash_form", array_of_hash: array_of_hash %>
-<!--if adding a new multi-part field that didn't exist before, you only need to handle array of hashes -->
-<%# elsif array_of_hash.class == Array %>
-  <%#= render "shared/ubiquity/alternate_identifier/new_form", array: array_of_hash %>
-<%# elsif array_of_hash.class == Hash %>
-  <%#= render "shared/ubiquity/alternate_identifier/edit_hash_form", hash: array_of_hash %>
 <% else %><!-- handle no record case -->
-<% end %> <%# closes if array_of_hash.class %>
+<% end %>

--- a/app/views/shared/ubiquity/alternate_identifier/_new_form.html.erb
+++ b/app/views/shared/ubiquity/alternate_identifier/_new_form.html.erb
@@ -1,4 +1,4 @@
-<% template = @curation_concern.class.to_s.underscore %>
+<% template = f.object.model.class.to_s.underscore %>
 
 <div class="ubiquity-meta-alternate-identifier" >
   <label class="control-label multi_value optional" for="<% template %>_alternate_identifier">Alternate identifier</label>

--- a/app/views/shared/ubiquity/dates/_date_accepted.html.erb
+++ b/app/views/shared/ubiquity/dates/_date_accepted.html.erb
@@ -1,7 +1,7 @@
 <%# see app/views/records/edit_fields/_date_accepted.html.erb %>
-<% template = @curation_concern.class.to_s.underscore %>
+<% template = f.object.model.class.to_s.underscore %>
 
 
-<%= render 'shared/ubiquity/dates/date_fields', date_type: 'accepted', template: template, curation_concern: @curation_concern %>
+<%= render 'shared/ubiquity/dates/date_fields', date_type: 'accepted', template: template, f: f %>
 
 <br/><br/><br/>

--- a/app/views/shared/ubiquity/dates/_date_fields.html.erb
+++ b/app/views/shared/ubiquity/dates/_date_fields.html.erb
@@ -3,12 +3,12 @@
 <p class="help-block"><%= t("simple_form.hints.defaults.date_#{date_type}") %></p>
 
 
-<%= select_year(parse_date(curation_concern.send("date_#{date_type}"), 'year').to_i, {start_year: (Date.today.year + 6), end_year: (Date.today.year - 159), prompt: "Select year"}, {name: "#{template}[date_#{date_type}_group][][date_#{date_type}_year]", class: "form-control ubiquity-date-#{date_type}-year ubiquity-date-input"} ) %>
+<%= select_year(parse_date(f.object.model.send("date_#{date_type}"), 'year').to_i, {start_year: (Date.today.year + 6), end_year: (Date.today.year - 159), prompt: "Select year"}, {name: "#{template}[date_#{date_type}_group][][date_#{date_type}_year]", class: "form-control ubiquity-date-#{date_type}-year ubiquity-date-input"} ) %>
 
-<%= select_month(parse_date(curation_concern.send("date_#{date_type}"), 'month').to_i, { use_two_digit_numbers: true,
+<%= select_month(parse_date(f.object.model.send("date_#{date_type}"), 'month').to_i, { use_two_digit_numbers: true,
                                                              prompt: 'select month if available'},   {name:  "#{template}[date_#{date_type}_group][][date_#{date_type}_month]", :class => "form-control ubiquity-date-#{date_type}-month ubiquity-date-input"}) %>
 
-<%= select_day(parse_date(curation_concern.send("date_#{date_type}"), 'day').to_i, { use_two_digit_numbers: true,
+<%= select_day(parse_date(f.object.model.send("date_#{date_type}"), 'day').to_i, { use_two_digit_numbers: true,
                                                         prompt: 'select day if available'},   {name:  "#{template}[date_#{date_type}_group][][date_#{date_type}_day]", :class => "form-control ubiquity-date-#{date_type}-day ubiquity-date-input"}) %>
 
 

--- a/app/views/shared/ubiquity/dates/_date_published.html.erb
+++ b/app/views/shared/ubiquity/dates/_date_published.html.erb
@@ -1,8 +1,8 @@
 <%# see app/views/records/edit_fields/_date_published.html.erb %>
-<% template = @curation_concern.class.to_s.underscore %>
+<% template = f.object.model.class.to_s.underscore %>
 
 
-<%= render 'shared/ubiquity/dates/date_fields', date_type: 'published', template: template, curation_concern: @curation_concern %>
+<%= render 'shared/ubiquity/dates/date_fields', date_type: 'published', template: template, f: f %>
 
 
 <br/><br/><br/>

--- a/app/views/shared/ubiquity/dates/_date_submitted.html.erb
+++ b/app/views/shared/ubiquity/dates/_date_submitted.html.erb
@@ -1,7 +1,7 @@
 <%# see app/views/records/edit_fields/_date_submitted.html.erb %>
-<% template = @curation_concern.class.to_s.underscore %>
+<% template = f.object.model.class.to_s.underscore %>
 
-<%= render 'shared/ubiquity/dates/date_fields', date_type: 'submitted', template: template, curation_concern: @curation_concern %>
+<%= render 'shared/ubiquity/dates/date_fields', date_type: 'submitted', template: template, f: f %>
 
 
 

--- a/app/views/shared/ubiquity/editor/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/editor/_edit_array_hash_form.html.erb
@@ -1,4 +1,5 @@
-<% template = curation_concern.class.to_s.underscore %>
+<% template = f.object.model.class.to_s.underscore %>
+
 
 <% array_of_hash.each_with_index do |hash, index| %>
 

--- a/app/views/shared/ubiquity/editor/_new_form.html.erb
+++ b/app/views/shared/ubiquity/editor/_new_form.html.erb
@@ -1,4 +1,5 @@
-<% template = curation_concern.class.to_s.underscore %>
+<% template = f.object.model.class.to_s.underscore %>
+
 
 <div class="ubiquity-meta-editor" >
 

--- a/app/views/shared/ubiquity/event_date/_event_date.html.erb
+++ b/app/views/shared/ubiquity/event_date/_event_date.html.erb
@@ -1,5 +1,5 @@
 <%# see app/views/records/edit_fields/_date_published.html.erb %>
-<% template = @curation_concern.class.to_s.underscore %>
+<% template = f.object.model.class.to_s.underscore %>
 
 
 <% event_date.each do |date| %>

--- a/app/views/shared/ubiquity/related_identifier/_edit_form.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_edit_form.html.erb
@@ -1,9 +1,4 @@
-<% array_of_hash = get_model(curation_concern.class, curation_concern.id, 'related_identifier') %>
 
-<!--
-Ensures the edit form still renders the related_identifier fields when it is nil instead of an array of hash
--->
-<% array_of_hash =  array_of_hash || [{}] %>
 
 <% if (array_of_hash.class == Array && array_of_hash.first.class == Hash)  %>
   <%= render "shared/ubiquity/related_identifier/edit_array_hash_form", array_of_hash: array_of_hash %>

--- a/app/views/shared/ubiquity/related_identifier/_new_form.html.erb
+++ b/app/views/shared/ubiquity/related_identifier/_new_form.html.erb
@@ -1,4 +1,4 @@
-<% template = @curation_concern.class.to_s.underscore %>
+<% template = f.object.model.class.to_s.underscore  %>
 
 <div class="ubiquity-meta-related-identifier" >
   <label class="control-label multi_value optional" for="<% template %>_related_identifier">Related identifier</label>

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,7 @@ module Hyku
       Hyrax::CollectionPresenter.class_eval {delegate :thumbnail_id, to: :solr_document}
       #Removes subject from collection click additional fields to see subject is gone
       Hyrax::Forms::CollectionForm.prepend(::Ubiquity::CollectionFormBehaviour)
+      Hyrax::Forms::BatchEditForm.prepend(::Ubiquity::AdditionalBatchEdit)
     end
 
     config.before_initialize do


### PR DESCRIPTION
Resolved : https://trello.com/c/NCuhUIda/412-05-bulk-edit-tool-in-dashboard-needs-more-options-of-fields-to-edit-and-fix-tate-tate
Institution as additional field has been added on the batch edit tool.