### PR TITLE
additional fix to creators showing on home and search page

### DIFF
--- a/app/helpers/multiple_metadata_fields_helper.rb
+++ b/app/helpers/multiple_metadata_fields_helper.rb
@@ -166,11 +166,17 @@ module MultipleMetadataFieldsHelper
   end
 
   def add_comma_if_both_names_present(hash, creator_names)
+
+    if  (hash['creator_organization_name'].present?)
+      creator_names <<  "#{hash['creator_organization_name']}"
+    end
     if  (hash['creator_given_name'].present? && hash['creator_family_name'].present? )
       add_comma = ','
       creator_names <<  "#{hash['creator_family_name']}#{add_comma} #{ hash['creator_given_name']}"
-    else
-      creator_names <<  "#{hash['creator_family_name']}#{add_comma}#{ hash['creator_given_name']}"
+    elsif hash['creator_family_name'].present?
+      creator_names <<  "#{hash['creator_family_name']}"
+    elsif  hash['creator_given_name'].present?
+      creator_names <<  hash['creator_given_name']
     end
   end
 

--- a/app/views/shared/ubiquity/search_display/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/search_display/_show_array_hash.html.erb
@@ -2,8 +2,9 @@
 <% array_of_hash.each do |hash| %>
   <span itemprop='<%= "#{attr_name}" %>' style="float:left;">
     <% if hash["#{attr_name}_organization_name"] %>
-      <%= hash["#{attr_name}_organization_name"] %>
+      <%= hash["#{attr_name}_organization_name"] %><span>; &nbsp;</span>
     <% end %>
+
     <% if hash["#{attr_name}_family_name"]  %>
       <% last_name = hash["#{attr_name}_family_name"] %>
       <% last_name << ',' if display_comma?(hash.keys, ["#{attr_name}_family_name", "#{attr_name}_given_name"]) %>


### PR DESCRIPTION
additional fix to creators showing on home and search page to fully resolve the below card
Resolved: https://trello.com/c/COKVGZGO/405-05-on-homepage-and-search-separate-creators-contributors-editors-with-a-semi-colon-instead-of-a-comma-also-on-search-run-all-cr