### PR TITLE
add license to avoid importer to crash for existing work

### DIFF
--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -20,6 +20,9 @@ terms:
     - id: https://creativecommons.org/publicdomain/mark/1.0/
       term: CC0 Public Domain Mark 1.0
       active: true
+    - id: http://creativecommons.org/publicdomain/mark/1.0/
+      term: CC0 Public Domain Mark 1.0
+      active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
       term: CC0 1.0 Universal Public Domain
       active: true


### PR DESCRIPTION
add license to avoid importer to crash for existing work

- id: http://creativecommons.org/publicdomain/mark/1.0/
  term: CC0 Public Domain Mark 1.0
  active: true
