### PR TITLE
change license to licence to match the British spelling

### DIFF
--- a/app/services/ubiquity/datacite_response.rb
+++ b/app/services/ubiquity/datacite_response.rb
@@ -69,7 +69,7 @@ module Ubiquity
        fields << 'DOI' if doi.present?
        fields << 'related_identifier' if related_identifier.present?
        fields << 'abstract' if abstract.present?
-       fields << 'license' if license.present?
+       fields << 'licence' if (license.present? && licence_present?.include?(license))
        #fields << 'version' if version.present?
 
        "The following fields were auto-populated - #{fields.to_sentence}"
@@ -123,6 +123,14 @@ module Ubiquity
        end
        new_creator_group
      end
+
+    #fetches list licences from config/authorities/licenses.yml
+    # returns each record in the form of ["CC BY 4.0 Attribution", "https://creativecommons.org/licenses/by/4.0/"]
+    # we are returning just the last part eg [ "https://creativecommons.org/licenses/by/4.0/"]
+    def licence_present?
+      licences = Hyrax::LicenseService.new.select_all_options
+      licences.map(&:last)
+    end
 
 
   end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -22,7 +22,7 @@ en:
   simple_form:
     hints:
       defaults:
-        license: "Licensing and distribution information governing access to the work.
+        license: "Licencing and distribution information governing access to the work.
                   Select from the provided drop-down list, or add to ‘additional information’ field below, if it is not included in the list"
         extent: "The extent (size, duration, number, etc.) of the work."
       labels:


### PR DESCRIPTION
Resolved: https://trello.com/c/69J4bTyw/422-01-review-and-update-the-dois-which-are-listed-in-the-help-text-for-datacite-auto-population

Work done: changing license to licence to match the British spelling

