### PR TITLE
version number editable from show page

### DIFF
--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -6,9 +6,10 @@ module Hyrax
     include ::Ubiquity::AllFormsSharedBehaviour
 
     self.model_class = ::Dataset
+    #version is used in the show page but populated by version_number from the edit and new form
     self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier
 
-                     version related_identifier publisher place_of_publication
+                     version_number related_identifier publisher place_of_publication
                      date_published date_accepted date_submitted abstract keyword library_of_congress_classification
                      institution org_unit refereed official_link related_url project_name funder fndr_project_ref
                      language license rights_statement rights_holder add_info]

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -5,10 +5,14 @@ module Hyrax
     include Hyrax::FormTerms
     include ::Ubiquity::AllFormsSharedBehaviour
     include Ubiquity::EditorMetadataFormBehaviour
+    include Ubiquity::VersionMetadataFormBehaviour
+
 
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
-    self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier version
+
+    #version is used in the show page but populated by version_number from the edit and new form
+    self.terms += %i[title resource_type creator contributor rendering_ids doi alternate_identifier version_number
                      related_identifier event_title event_date event_location series_name volume edition journal_title
                      issue pagination editor publisher place_of_publication isbn issn eissn article_num media
                      date_published date_accepted date_submitted abstract keyword library_of_congress_classification

--- a/app/forms/ubiquity/version_metadata_form_behaviour.rb
+++ b/app/forms/ubiquity/version_metadata_form_behaviour.rb
@@ -1,0 +1,18 @@
+module Ubiquity
+  module VersionMetadataFormBehaviour
+    extend ActiveSupport::Concern
+
+    included do
+      attr_accessor :version_number
+    end
+
+    class_methods do
+      def build_permitted_params
+        super.tap do |permitted_params|
+          permitted_params << {version_number: []}
+        end
+      end
+    end
+
+  end
+end

--- a/app/models/concerns/ubiquity/shared_metadata.rb
+++ b/app/models/concerns/ubiquity/shared_metadata.rb
@@ -58,9 +58,15 @@ module Ubiquity
       property :related_exhibition_date, predicate: ::RDF::Vocab::SCHEMA.term(:Date) do |index|
         index.as :stored_searchable
       end
-      property :version, predicate: ::RDF::Vocab::BF2.version do |index|
+
+      property :version, predicate: ::RDF::Vocab::SCHEMA.version do |index|
         index.as :stored_searchable
       end
+
+      property :version_number, predicate: ::RDF::Vocab::SCHEMA.version do |index|
+        index.as :stored_searchable
+      end
+
     end
   end
 end

--- a/app/models/concerns/ubiquity/version_metadata_model_concern.rb
+++ b/app/models/concerns/ubiquity/version_metadata_model_concern.rb
@@ -1,0 +1,18 @@
+#Included in any work that requires saving version number. Currently used in Dataset and GenericWork
+module Ubiquity
+  module VersionMetadataModelConcern
+    extend ActiveSupport::Concern
+    include Ubiquity::AllModelsVirtualFields
+
+    included do
+      before_save :save_version
+    end
+
+    private
+
+    def save_version
+      self.version = self.version_number
+    end
+
+  end
+end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -5,6 +5,7 @@ class GenericWork < ActiveFedora::Base
   include Ubiquity::BasicMetadataDecorator
   include Ubiquity::AllModelsVirtualFields
   include Ubiquity::EditorMetadataModelConcern
+  include Ubiquity::VersionMetadataModelConcern
 
   validates :title, presence: { message: 'Your work must have a title.' }
 


### PR DESCRIPTION
Resolved: https://trello.com/c/eVYq8fxF/427-05-version-number-added-via-the-importer-is-not-editable