### PR TITLE
thumbnail alignment work for firefox and chrome

### DIFF
--- a/app/views/shared/ubiquity/_thumbnail.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail.html.erb
@@ -10,5 +10,5 @@ app/views/hyrax/dashboard/works/_list_works.html.erb
     <%= render 'shared/ubiquity/thumbnail_icons', document: document,  presenter: presenter %>
    <% end %>
 <% else %>
-  <span class="media-left hidden-xs file_listing_thumbnail " ></span>
+  <span class="media-left hidden-xs file_listing_thumbnail" style="padding-left:62px" ></span>
 <% end %>

--- a/app/views/shared/ubiquity/_thumbnail_icons.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_icons.html.erb
@@ -10,9 +10,9 @@
 <% elsif (ubiquity_thumbnail_format == ".pdf") && (document.thumbnail_path.split('?').last == "file=thumbnail") %>
   <span class="fa fa-file-pdf-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>
 <% elsif ([".docx", '.doc'].include? check_file_extension(file_set_presenter.solr_document.label)) && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>
-    <span class="fa fa-file-word-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>
+  <span class="fa fa-file-word-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>
 <% elsif (document.thumbnail_path.split('?').last == "file=thumbnail") && ([".docx", '.doc', '.pdf'].exclude? check_file_extension(file_set_presenter.solr_document.label)) && (zipped_types.exclude? check_file_extension(file_set_presenter.solr_document.label) )   %>
-    <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span> 
+  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>
 <% else %>
-     <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+  <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
  <% end %>

--- a/app/views/shared/ubiquity/_thumbnail_icons_with_restrictions.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_icons_with_restrictions.html.erb
@@ -10,16 +10,19 @@
 <% if zipped_types.include? check_file_extension(file_set_presenter.solr_document.label) %>
   <span class="fa fa-file-archive-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span><span style="width:100px;padding-left:108px"></span>
 <% elsif (check_file_extension(file_set_presenter.solr_document.label) == ".pdf") && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>
-  <span class="fa fa-file-pdf-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> <span style="width:100px;padding-left:105px"></span>
+  <span class="fa fa-file-pdf-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> <span style="width:100px;padding-left:115px"></span>
 <% elsif ([".docx", '.doc'].include? check_file_extension(file_set_presenter.solr_document.label)) && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>
-  <span class="fa fa-file-word-o  fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span><span style="color:grey;width:100px;padding-left:105px;"></span>
+  <span class="fa fa-file-word-o  fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span><span style="color:grey;width:100px;padding-left:115px;"></span>
 <% elsif (document.thumbnail_path.split('?').last == "file=thumbnail") && ([".docx", '.doc', '.pdf'].exclude? check_file_extension(file_set_presenter.solr_document.label)) && (zipped_types.exclude? check_file_extension(file_set_presenter.solr_document.label) ) %>
-  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:108px"></span>
+  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
 <% elsif (check_file_is_restricted?(file_set_presenter) == nil && (file_set_presenter.lease_expiration_date.present?) && (file_set_presenter.embargo_release_date.present?)) %>
-  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:108px"></span>
+  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
 <% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) ) %>
   <%= render_thumbnail_tag(document, {width: 90, class: 'hidden-xs file_listing_thumbnail'}, {suppress_link: true}) %>
 <% else %>
- <!-- displays for logged out users on files with embargo/lease -->
+ <!-- displays for logged out users on files with embargo/lease
   <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>
+  -->
+  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
+
 <% end %>

--- a/app/views/shared/ubiquity/collections/_list_collections.html.erb
+++ b/app/views/shared/ubiquity/collections/_list_collections.html.erb
@@ -14,10 +14,10 @@
       <!-- This if condiftion was added by UbiquityPress -->
       <% if document.thumbnail_id %>
         <% if File.extname(document.thumbnail_path).blank? %>
-          <span class="fa fa-file-archive-o grey-zip-icon pull-left collection-icon-small"></span>
+         <span class="fa fa-file-archive-o grey-zip-icon pull-left collection-icon-small"></span>
         <% else %>
           <span  class="collection-icon-small pull-left"><%= render_thumbnail_tag document, :style => 'width:18px' %></span>
-        <% end %>
+      <% end %>
       <% else %>
           <!-- this was the default in hyrax -->
           <span class="<%# Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small pull-left"></span>

--- a/app/views/shared/ubiquity/collections/_show_document_list_row.html.erb
+++ b/app/views/shared/ubiquity/collections/_show_document_list_row.html.erb
@@ -1,9 +1,11 @@
 <%#
+  displays dashboard collection list including the works 
  Copied from https://github.com/samvera/hyrax/blob/v2.0.2/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
     and
     called in app/views/hyrax/collections/_show_document_list_row.html.erb
     https://github.com/samvera/hyrax/blob/v2.0.2/app/views/hyrax/collections/_show_document_list_row.html.erb
     Consolidated since there is just a minor change of showing edit button when rendered via dashboard
+
 %>
 
 <% id = document.id %>
@@ -19,7 +21,7 @@
         <%= render 'shared/ubiquity/thumbnail', document: document,  presenter: Hyku::ManifestEnabledWorkShowPresenter.new(document, current_ability) %>
       <% else %>
         <%= link_to "", class: 'media-left', 'aria-hidden' => true do %>
-          <span class="media-left hidden-xs file_listing_thumbnail" style="height:55px;width:50px;padding-left: 60px;" ></span>
+          <span class="media-left hidden-xs file_listing_thumbnail" style="height:55px;width:50px;padding-left: 55px;" ></span>
         <% end %>
       <% end %>
       <div class="media-body">


### PR DESCRIPTION
Resolved: https://trello.com/c/wBa3vjeS/431-01-default-icon-for-doc-docx-where-thumbnail-has-not-been-generated-needs-amending
This fixes resolve the thumbnail alignment when using Firefox and Chrome