### PR TITLE
change archive icon to file icon for collection list

### DIFF
--- a/app/views/shared/ubiquity/collections/_list_collections.html.erb
+++ b/app/views/shared/ubiquity/collections/_list_collections.html.erb
@@ -14,7 +14,7 @@
       <!-- This if condiftion was added by UbiquityPress -->
       <% if document.thumbnail_id %>
         <% if File.extname(document.thumbnail_path).blank? %>
-         <span class="fa fa-file-archive-o grey-zip-icon pull-left collection-icon-small"></span>
+         <span class="fa fa-file-o grey-zip-icon pull-left collection-icon-small"></span>
         <% else %>
           <span  class="collection-icon-small pull-left"><%= render_thumbnail_tag document, :style => 'width:18px' %></span>
       <% end %>


### PR DESCRIPTION
Resolved: https://trello.com/c/UzsqxaRq/458-fix-collection-list-page-to-show-all-the-different-thumbnail-options