### PR TITLE
Featured thumbnail fix

### DIFF
--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -1,18 +1,33 @@
 <%# Override from Hyrax engine to customise front-end %>
-<!-- instance  of Hyrax::WorkShowPresenter: -->
-
+<!-- featured instance  of Hyrax::WorkShowPresenter: -->
 <% featured_doc = featured.solr_document %>
+<% if featured.thumbnail_id.present? %>
 
-<div class="featured-fields" >
-  <%= link_to [main_app, featured] do %>
-    <div class="featured-item-thumbnail">
-      <%= render_related_img(featured_doc) %>
+  <div class="featured-fields" >
+    <%= link_to [main_app, featured] do %>
+      <div class="featured-item-thumbnail">
+        <%= render 'shared/ubiquity/thumbnail_featured', document: featured_doc %>
+      </div>
+      <div class="featured-item homepage-field-title">
+        <%= featured.title.first %>
+      </div>
+    <% end %>
+    <div class="featured-item">
+      <%= link_to_facet_list(featured_doc['creator_search_tesim'], 'creator_search').html_safe %>
     </div>
-    <div class="featured-item homepage-field-title">
-      <%= featured.title.first %>
+  </div>
+<% else %>
+<div>
+  <div class="featured-item-title">
+    <h3>
+      <span class="sr-only">Title</span><%= link_to (featured_doc.to_s), [main_app, featured_doc] %>
+      <%= link_to [main_app, featured] do %>
+        <span class="media-left hidden-xs file_listing_thumbnail" style="padding-left:62px" ></span>
+      <% end %>
+    </h3>
+    <div class="featured-item">
+      <%= link_to_facet_list(extract_creator_names_for_homepage(featured_doc), 'creator_search').html_safe %>
     </div>
-  <% end %>
-  <div class="featured-item">
-    <%= link_to_facet_list(featured_doc['creator_search_tesim'], 'creator_search').html_safe %>
   </div>
 </div>
+<% end %>

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -1,3 +1,5 @@
+<!--  recent_document instance  of solr_document -->
+
 <%# Fix to not display default image icon. This file was copied from
   https://github.com/samvera/hyrax/blob/37a1c370cd05a7ed0a8ca2ad453bc15eb812f132/app/views/hyrax/homepage/_recent_document.html.erb
  %>

--- a/app/views/shared/ubiquity/_thumbnail_featured.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_featured.html.erb
@@ -1,0 +1,28 @@
+
+<!-- used in
+  app/views/hyrax/homepage/_featured_fields.html.erb
+
+-->
+
+<% presenter = Hyku::ManifestEnabledWorkShowPresenter.new(document, current_ability) %>
+<% file_set_presenter = presenter.thumbnail_presenter %>
+
+<% if zipped_types.include? check_file_extension(file_set_presenter.solr_document.label) %>
+  <span class="fa fa-file-archive-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span><span style="width:100px;padding-left:108px"></span>
+<% elsif (check_file_extension(file_set_presenter.solr_document.label) == ".pdf") && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>
+  <span class="fa fa-file-pdf-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> <span style="width:100px;padding-left:115px"></span>
+<% elsif ([".docx", '.doc'].include? check_file_extension(file_set_presenter.solr_document.label)) && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>
+  <span class="fa fa-file-word-o  fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span><span style="color:grey;width:100px;padding-left:115px;"></span>
+<% elsif (document.thumbnail_path.split('?').last == "file=thumbnail") && ([".docx", '.doc', '.pdf'].exclude? check_file_extension(file_set_presenter.solr_document.label)) && (zipped_types.exclude? check_file_extension(file_set_presenter.solr_document.label) ) %>
+  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
+<% elsif (check_file_is_restricted?(file_set_presenter) == nil && (file_set_presenter.lease_expiration_date.present?) && (file_set_presenter.embargo_release_date.present?)) %>
+  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
+<% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) ) %>
+  <%= render_thumbnail_tag(document, {width: 90, class: 'hidden-xs file_listing_thumbnail'}, {suppress_link: true}) %>
+<% else %>
+ <!-- displays for logged out users on files with embargo/lease
+  <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>
+  -->
+  <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
+
+<% end %>

--- a/app/views/shared/ubiquity/collections/_list_collections.html.erb
+++ b/app/views/shared/ubiquity/collections/_list_collections.html.erb
@@ -14,7 +14,7 @@
       <!-- This if condiftion was added by UbiquityPress -->
       <% if document.thumbnail_id %>
         <% if File.extname(document.thumbnail_path).blank? %>
-         <span class="fa fa-file-archive-o grey-zip-icon pull-left collection-icon-small"></span>
+         <span class="fa fa-file-o grey-zip-icon pull-left collection-icon-small"></span>
         <% else %>
           <span  class="collection-icon-small pull-left"><%= render_thumbnail_tag document, :style => 'width:18px' %></span>
       <% end %>


### PR DESCRIPTION
Resolved: https://trello.com/c/CRzci9C9/457-featured-work-shows-broken-thumbnail-for-logged-in-users

Resolved: https://trello.com/c/sFRbK0nD/463-doc-file-thumbnails-are-not-showing-on-featured-on-homepage