### PR TITLE
fix alignment for both show and search page

### DIFF
--- a/app/views/shared/ubiquity/_thumbnail_icons_with_restrictions.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_icons_with_restrictions.html.erb
@@ -8,7 +8,7 @@
 <% file_set_presenter = presenter.thumbnail_presenter %>
 
 <% if zipped_types.include? check_file_extension(file_set_presenter.solr_document.label) %>
-  <span class="fa fa-file-archive-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span><span style="width:100px;padding-left:108px"></span>
+  <span class="fa fa-file-archive-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span><span style="width:100px;padding-left:115px"></span>
 <% elsif (check_file_extension(file_set_presenter.solr_document.label) == ".pdf") && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>
   <span class="fa fa-file-pdf-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> <span style="width:100px;padding-left:115px"></span>
 <% elsif ([".docx", '.doc'].include? check_file_extension(file_set_presenter.solr_document.label)) && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>

--- a/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
+++ b/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
@@ -8,7 +8,7 @@
     <% file_set_presenter = presenter.thumbnail_presenter %>
 
     <% if zipped_types.include? check_file_extension(file_set_presenter.solr_document.label) %>
-      <span class="fa fa-file-archive-o fa-5x grey-zip-icon" style="color:grey;padding-left:70px"></span>
+      <span class="fa fa-file-archive-o fa-5x grey-zip-icon" style="color:grey;padding-left:60px"></span>
     <% elsif (check_file_extension(file_set_presenter.solr_document.label) == ".pdf") && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>
       <span class="fa fa-file-pdf-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:60px"></span> <span style="padding-left:125px"></span>
     <% elsif ([".docx", '.doc'].include? check_file_extension(file_set_presenter.solr_document.label)) && (document.thumbnail_path.split('?').last == "file=thumbnail")  %>


### PR DESCRIPTION
Resolved: https://trello.com/c/0BdBttYX/461-default-icon-for-archives-needs-a-bit-more-horizontal-space-on-homepage

Resolved: https://trello.com/c/JZUZW5NE/462-reduce-space-to-left-of-default-icon-for-archives-on-search-results-page