### PR TITLE
Fix broken thumbnail for collections

### DIFF
--- a/app/views/hyrax/collections/_media_display.html.erb
+++ b/app/views/hyrax/collections/_media_display.html.erb
@@ -5,10 +5,7 @@
   %>
 
 <% if presenter.thumbnail_id %>
-   <%= image_tag presenter.thumbnail_path,
-                class: "representative-media",
-                alt: "",
-                role: "presentation" %>
+   <%= render 'shared/ubiquity/thumbnail_icons_with_restrictions',  document: presenter.solr_document  %>
 <% else %>
   <%# The line below is commented out by UbiquityPress%>
   <span class="<%# Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search"></span>


### PR DESCRIPTION
Resolved : https://trello.com/c/Ecgh4hNv/459-fix-broken-thumbnail-image-when-click-on-collection-show-page-from-dashboard-and-from-home-page