### PR TITLE
remove home link from breadcrumb

### DIFF
--- a/app/controllers/concerns/ubiquity/breadcrumb_override.rb
+++ b/app/controllers/concerns/ubiquity/breadcrumb_override.rb
@@ -1,12 +1,19 @@
+#overriding methods from https://github.com/samvera/hyrax/blob/master/app/controllers/concerns/hyrax/breadcrumbs.rb
+
 module Ubiquity
   module BreadcrumbOverride
     include Hyrax::BreadcrumbsForWorks
+
+    def default_trail
+      #add_breadcrumb I18n.t('hyrax.controls.home'), hyrax.root_path
+      add_breadcrumb I18n.t('hyrax.dashboard.title'), hyrax.dashboard_path if user_signed_in?
+    end
 
     # Don't display `add_breadcrumb_for_action` when a user is not signed_in
     def trail_from_referer
       case request.referer
       when /catalog/
-        add_breadcrumb I18n.t('hyrax.controls.home'), hyrax.root_path
+        #add_breadcrumb I18n.t('hyrax.controls.home'), hyrax.root_path
         add_breadcrumb I18n.t('hyrax.bread_crumb.search_results'), request.referer
       else
         default_trail


### PR DESCRIPTION
Resolved: In the 'show work' page, remove the 'Home / ' link - so it just reads 'Back to search results'.

Featured on shared search card below

https://trello.com/c/V8ThsGkQ/102-enable-search-across-all-repositories-from-the-shared-layer-search-navigation