### PR TITLE
enable json importer to populate works with account_cname

### DIFF
--- a/app/services/ubiquity/json_importer.rb
+++ b/app/services/ubiquity/json_importer.rb
@@ -38,6 +38,7 @@ module Ubiquity
         populate_json_field(key, val)
         populate_single_fields(key, val)
       end
+      @work_instance.account_cname = @tenant_domain
       @work_instance.date_modified = Hyrax::TimeService.time_in_utc
       @work_instance.date_uploaded = Hyrax::TimeService.time_in_utc unless @work_instance.date_uploaded.present?
       puts "#{@work_instance.inspect}"


### PR DESCRIPTION
This is related to the work on shared search

https://trello.com/c/V8ThsGkQ/102-enable-search-across-all-repositories-from-the-shared-layer-search-navigation