### PR TITLE
hide restricted files, revise search display and move model to search to environment variable

### DIFF
--- a/app/helpers/ubiquity/shared_search_helper.rb
+++ b/app/helpers/ubiquity/shared_search_helper.rb
@@ -19,5 +19,13 @@ module Ubiquity
       end
     end
 
+    def  get_thumbnail_visibility(file_id, tenant)
+      if file_id.present? && tenant.present?
+        AccountElevator.switch!(tenant)
+        @work ||= ActiveFedora::Base.find(file_id)
+        @work.try(:thumbnail).try(:visibility) 
+      end
+    end
+
   end
 end

--- a/app/views/ubiquity/shared_search/index.html.erb
+++ b/app/views/ubiquity/shared_search/index.html.erb
@@ -22,15 +22,19 @@
 
                 <h2>
                 <span class="search-meta-label"><span class="attribute-label h4">
-                  <%= link_to data_value.first, url, target: "_blank" %></span></span>
+                  <%= link_to data_value.first, url %></span></span>
                 </h2>
                 <div class="list-thumbnail">
-                <% if model["thumbnail_path_ss"].present? && File.extname(model['thumbnail_path_ss']).blank?  %>
+                <% if model["thumbnail_path_ss"].present?   %>
+                    <% if  File.extname(model['thumbnail_path_ss']).blank? %>
                       <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;width:150px;padding-left:25px"></span>
-                <% elsif model["thumbnail_path_ss"].present? && model["thumbnail_path_ss"] != "/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png" %>
-                    <img src="<%= request.protocol %><%= model["account_cname_tesim"].try(:first) %>:<%= request.port %><%= image_path(model['thumbnail_path_ss']) %>" alt="default" style="width:150px;padding-left:25px" >
+                    <% elsif get_thumbnail_visibility(model['id'], model["account_cname_tesim"].try(:first)) != 'open' && model["thumbnail_path_ss"] != "/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png" %>
+                      <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;width:150px;padding-left:25px"></span>
+                    <% elsif model["thumbnail_path_ss"] != "/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png" %>
+                      <img src="<%= request.protocol %><%= model["account_cname_tesim"].try(:first) %>:<%= request.port %><%= image_path(model['thumbnail_path_ss']) %>" alt="default" style="width:150px;padding-left:25px">
+                    <% end %>
                 <% else %>
-                  <span class="<%# Hyrax::ModelIcon.css_class_for(Collection) %> list-thumbnail"></span> <br/>
+                  <span class="<%# Hyrax::ModelIcon.css_class_for(Collection) %> list-thumbnail"></span>    <br/>
                  <% end %>
                  </div> <!--  closes list-thumbnail -->
 
@@ -40,25 +44,33 @@
                <div class="col-md-8 pull-right">
 
                     <% if (["creator_tesim"].include? hash_key) && data_value.present? %>
-
+                       <hr>
                        <% field = parse_json(data_value) %>
                         <span class="search-meta-label pull-left"><span class="attribute-label h4"><%= Ubiquity::SharedSearch::NAME_MAPPING[hash_key] %></span></span>
 
                         <span class="pull-right text-left"><span class="center-block"><%= render "shared/ubiquity/search_display/show_array_hash", array_of_hash: field, attr_name: 'creator' %></span></span>
-
                      <% end %>
 
-                     <% if (["resource_type_tesim", "date_published_tesim", "institution_tesim"].include? hash_key) && data_value.present? %>
-
+                     <% if (["date_published_tesim"].include? hash_key) && data_value.present? %>
+                        <hr>
                         <span class="search-meta-label pull-left"><span class=" attribute-label h4"><%= Ubiquity::SharedSearch::NAME_MAPPING[hash_key] %></span> </span>
 
-                        <span class="pull-right"><% if data_value.class != Array %> <span class="center-block"><%= data_value %> <% end %> </span></span>
-                        <span class="pull-right"><% if data_value.class == Array %>  <span class="text-right"> <%= data_value.to_sentence %> <% end %> </span> </span>
-
+                        <span class="pull-right"><% if data_value.class == Array %> <span class="center-block"><%= data_value.first %> <% end %> </span></span>
                      <% end %>
 
-                 </div> <!--  closes col-md-6 -->
+                     <% if (["resource_type_tesim"].include? hash_key) && data_value.present? %>
+                        <hr>
+                        <span class="search-meta-label pull-left"><span class=" attribute-label h4"><%= Ubiquity::SharedSearch::NAME_MAPPING[hash_key] %></span> </span>
+                        <span class="pull-right"><% if data_value.class == Array %> <span class="center-block"><%= human_readable_resource_type(data_value) %> <% end %> </span></span>
+                     <% end %>
 
+                     <% if (["institution_tesim"].include? hash_key) && data_value.present? %>
+                        <hr>
+                        <span class="search-meta-label pull-left"><span class=" attribute-label h4"><%= Ubiquity::SharedSearch::NAME_MAPPING[hash_key] %></span> </span>
+                        <span class="pull-right"><% if data_value.class == Array %>  <span class="text-right"> <%= safe_join(data_value, '; ').html_safe %> <% end %> </span> </span>
+
+                     <% end %>
+                </div> <!--  closes col-md-8 -->
 
               <% end %> <!-- model each loop -->
                </div> <!-- closes .row -->


### PR DESCRIPTION
Further refinement to the features in this card:
https://trello.com/c/V8ThsGkQ/102-enable-search-across-all-repositories-from-the-shared-layer-search-navigation

- Moved list of models to search to environment variable:
The list of models to search now come from environment variable. In the format:

        SHARED_SEARCH_TYPES="Article, Book, BookContribution, ConferenceItem, Dataset, Image, Report, GenericWork"

So it is a list of strings.

- revised search display to have <hr> lines after each metadata in a work
- use default thumbnails for files under  embargo
- ensure resource_type displays correctly
- separate multiple institutions by semi-colon