### PR TITLE
add gtm scripts to shared layer pages

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -88,7 +88,9 @@ module Hyku
         "tate-demo" => ENV["TATE-DEMO_GTM_ID"],
         "britishmuseum-demo" => ENV["BRITISHMUSEUM-DEMO_GTM_ID"],
         "nms-demo" => ENV["NMS-DEMO_GTM_ID"],
-        "sandbox" => ENV["SANDBOX-DEMO_GTM_ID"]
+        "sandbox" => ENV["SANDBOX-DEMO_GTM_ID"],
+        "repo-test" => ENV["REPOTEST_GTM_ID"],
+        "oar" => ENV["OAR_GTM_ID"]
     }
   end
 end


### PR DESCRIPTION
Resolved: https://trello.com/c/MuCsFT66/489-add-google-tag-manager-to-shared-layer-pages

@fradeve the below environment variables will also need to be added on kubernetes config map.

ENV["REPOTEST_GTM_ID"]
ENV["OAR_GTM_ID"]