### PR TITLE
Shared search

### DIFF
--- a/app/views/ubiquity/shared_search/_search_page_top.html.erb
+++ b/app/views/ubiquity/shared_search/_search_page_top.html.erb
@@ -41,22 +41,22 @@
 
     <div class="row">
       <div class="col-md-7 col-md-offset-5">
-        <div id="SortAndPage" class="clearfix">
-          <div class="page_links" aria-hidden="true">
-            <span class="page_entries">No entries found</span>
-          </div>
+        <div class="page_links" aria-hidden="true">
+          <span class="page_entries">No entries found</span>
         </div>
+        <hr>
+        <h2 class="sr-only">Search Results</h2>
         <h2>No results found for your search</h2>
         <div id="documents" class="noresults">
           <h3>Try modifying your search<h3>
-          <ul>
+          <!-- <ul>
             <h5>
               <li>Use fewer keywords to start, then refine your search using the links on the left</li>
             </h5>
-          </ul>
-       </div>
+          </ul> -->
+        </div>
+      </div>
     </div>
-  </div>
-
-</div>  <!-- closes .container for form -->
+  </div>  <!-- closes .container for form -->
+  
 <% end %>

--- a/app/views/ubiquity/shared_search/_search_page_top.html.erb
+++ b/app/views/ubiquity/shared_search/_search_page_top.html.erb
@@ -30,7 +30,7 @@
 
   </div>  <!-- closes .container for form -->
 <% else %>
-  
+
   <div class="container">
 
     <div class="row">
@@ -40,11 +40,23 @@
     </div> <!-- closes .row -->
 
     <div class="row">
-       <div class="col-md-7 col-md-offset-5">
-        <h3 class="text-danger">No results found for your search term </h3>
-        <p> Try modifying your search term </p>
+      <div class="col-md-7 col-md-offset-5">
+        <div id="SortAndPage" class="clearfix">
+          <div class="page_links" aria-hidden="true">
+            <span class="page_entries">No entries found</span>
+          </div>
+        </div>
+        <h2>No results found for your search</h2>
+        <div id="documents" class="noresults">
+          <h3>Try modifying your search<h3>
+          <ul>
+            <h5>
+              <li>Use fewer keywords to start, then refine your search using the links on the left</li>
+            </h5>
+          </ul>
        </div>
     </div>
+  </div>
 
-  </div>  <!-- closes .container for form -->
+</div>  <!-- closes .container for form -->
 <% end %>

--- a/app/views/ubiquity/shared_search/index.html.erb
+++ b/app/views/ubiquity/shared_search/index.html.erb
@@ -1,6 +1,8 @@
 
 <%= render "search_page_top", search_pagination: @search_pagination  %>
-<br/><hr>
+<% if @search_pagination.present? %>
+  <br/><hr>
+<% end %>
 <div class="container-fluid id="search-results"">
   <div class="row">
     <div class="col-md-3"><!-- facet sidebar --> </div>
@@ -26,8 +28,8 @@
               <% end %>  <!-- closes if title_tesim -->
               <div class="metadata">
                 <table class="table">
-                  <% model.each do |hash_key, data_value| %>
                     <tbody>
+                  <% model.each do |hash_key, data_value| %>
 
                       <% if (["creator_tesim"].include? hash_key) && data_value.present? %>
                         <% field = parse_json(data_value) %>
@@ -76,8 +78,9 @@
                           </td>
                         </tr>
                       <% end %>
-                    </tbody>
+
                   <% end %> <!-- model each loop -->
+                    </tbody>
                 </table>
               </div>
 


### PR DESCRIPTION
Resolved: https://trello.com/c/h3ql9tXY/491-shared-search-where-no-results-are-returned.

This pull request also contain a fix (display every line above each field: creator, institution, date_published, resource_type) obtained by repositioning the <t/body> outside the model.each loop.

File changed below: app/views/ubiquity/shared_search/index.html.erb