### PR TITLE
add link back to search result for shared search

### DIFF
--- a/app/controllers/concerns/ubiquity/breadcrumb_override.rb
+++ b/app/controllers/concerns/ubiquity/breadcrumb_override.rb
@@ -15,11 +15,14 @@ module Ubiquity
       when /catalog/
         #add_breadcrumb I18n.t('hyrax.controls.home'), hyrax.root_path
         add_breadcrumb I18n.t('hyrax.bread_crumb.search_results'), request.referer
+      when //
+        add_breadcrumb I18n.t('hyrax.bread_crumb.search_results'), request.referer
       else
         default_trail
         add_breadcrumb_for_controller if user_signed_in?
         add_breadcrumb_for_action if user_signed_in?
       end
     end
+
   end
 end

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,5 +1,6 @@
 
 <% provide :page_title, @presenter.page_title %>
+<%= render 'shared/ubiquity/works/breadcrumbs_js' %>
 <%= render 'shared/citations' %>
 <%= render './shared/additional_citations' %>
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">

--- a/app/views/shared/ubiquity/works/_breadcrumbs_js.html.erb
+++ b/app/views/shared/ubiquity/works/_breadcrumbs_js.html.erb
@@ -1,0 +1,12 @@
+<!-- rendered in  /home/antonio/hyku/hyku/app/views/hyrax/base/show.html.erb
+      to override back to search result link when request.referer is empty
+-->
+
+<script type='text/javascript'>
+    $(document).on("turbolinks:load", function(){
+      return $("body").on("click", ".breadcrumb", function(event){
+        event.preventDefault();
+        window.history.back();
+     });
+  });
+</script>


### PR DESCRIPTION
Resolved: https://trello.com/c/LTvrCeX0/486-15-breadcrumb-back-to-search-result-link-on-shared-search