### PR TITLE
fix for .zip file icon not showing

### DIFF
--- a/app/views/ubiquity/shared_search/_shared_search_thumbnail.html.erb
+++ b/app/views/ubiquity/shared_search/_shared_search_thumbnail.html.erb
@@ -3,7 +3,7 @@
 -->
 
 <%  thumbnail_label = get_thumbnail_label(model['id'], model["account_cname_tesim"].try(:first))%>
-<% if zipped_types.include? thumbnail_label%>
+<% if zipped_types.include? check_file_extension(thumbnail_label)%>
   <div class="list-thumbnail">
     <span class="fa fa-file-archive-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:60px"></span>
   </div>


### PR DESCRIPTION
Resolves: https://trello.com/c/V3gnsBrU/512-fix-archivezip-icon-not-showing-on-shared-search