### PR TITLE
Shared search pagination

### DIFF
--- a/app/views/ubiquity/shared_search/_search_page_top.html.erb
+++ b/app/views/ubiquity/shared_search/_search_page_top.html.erb
@@ -20,7 +20,9 @@
     <div class="row">
       <!--  col-md-offset-2 -->
       <div class="col-md-5 col-md-offset-3">
-        <%= paginate @search_pagination %>
+        <%= link_to_prev_page @search_pagination, '<< Previous |' %>
+        <%= page_entries_info(search_pagination)%>
+        <%= link_to_next_page @search_pagination, '| Next >>' %>
       </div>
 
     <!-- cookie used instead of passing a default value to options_from_collection_for_select, so we can always display included_blank -->

--- a/app/views/ubiquity/shared_search/_search_page_top.html.erb
+++ b/app/views/ubiquity/shared_search/_search_page_top.html.erb
@@ -20,12 +20,11 @@
     <div class="row">
       <!--  col-md-offset-2 -->
       <div class="col-md-5 col-md-offset-3">
-        <%= link_to_prev_page @search_pagination, '<< Previous |' %>
+        <%= link_to_prev_page @search_pagination, '« Previous |' %>
         <%= page_entries_info(search_pagination)%>
-        <%= link_to_next_page @search_pagination, '| Next >>' %>
+        <%= link_to_next_page @search_pagination, '| Next »' %>
       </div>
 
-    <!-- cookie used instead of passing a default value to options_from_collection_for_select, so we can always display included_blank -->
     <% params[:sort] = cookies[:sort] %>
     <% default_sort_value = params[:sort] %>
     <% selected_option_label = generate_sort_label(default_sort_value) %>
@@ -33,8 +32,7 @@
     <% params[:per_page] = cookies[:per_page] %>
     <% default_value = params[:per_page] %>
 
-  <!-- pagination class added to allow the dropdowns to be in line with pagination buttons -->
-  <div class="pagination pull-right col-md-4">
+  <div class="pull-right col-md-4">
    <div id="sort-dropdown" class="btn-group">
      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
       Sort by <%= selected_option_label %> <span class="caret"></span>


### PR DESCRIPTION
Resolves: https://trello.com/c/nodTRVM4/506-1-shared-search-show-the-total-number-of-results-in-search-results-page-assuming-more-than-0

Resolves: https://trello.com/c/Sj5NQ9yj/507-1-shared-search-in-results-make-pagination-the-same-as-on-individual-repos