### PR TITLE
add shared-search faceting

### DIFF
--- a/app/models/concerns/ubiquity/basic_metadata_decorator.rb
+++ b/app/models/concerns/ubiquity/basic_metadata_decorator.rb
@@ -3,12 +3,12 @@ module Ubiquity
     extend ActiveSupport::Concern
     include Ubiquity::CsvExportUtil
     include Ubiquity::WorkAndCollectionMetadata
-    
+
     # include here properties (fields) shared across all templates
     # also see SharedMetadata
     included do
       property :institution, predicate: ::RDF::Vocab::ORG.organization do |index|
-        index.as :stored_searchable
+        index.as :stored_searchable, :facetable
       end
       property :org_unit, predicate: ::RDF::Vocab::ORG.OrganizationalUnit do |index|
         index.as :stored_searchable

--- a/app/services/concerns/ubiquity/shared_search_util.rb
+++ b/app/services/concerns/ubiquity/shared_search_util.rb
@@ -1,0 +1,31 @@
+module Ubiquity
+  module SharedSearchUtil
+    extend ActiveSupport::Concern
+    included do
+      Hash_keys = ["system_create_dtsi", "id", "depositor_ssim", "title_tesim", "creator_search_tesim",
+                  "creator_tesim",  "date_published_tesim", "resource_type_tesim", "account_cname_tesim",  "pagination_tesim", "institution_tesim",
+                  "resource_type_tesim", "thumbnail_path_ss", "file_set_ids_ssim",
+                  "visibility_ssi", "has_model_ssim" ].freeze
+
+      NAME_MAPPING = {
+        "system_create_dtsi" => 'Date Created', "title_tesim" => 'Title',
+        "creator_tesim" => 'Creator:', "resource_type_tesim" => 'Resource Type:',
+        "date_published_tesim" => "Date Published:", "institution_tesim" => 'Institution:'
+      }.freeze
+
+      PER_PAGE_OPTIONS = [10, 20, 50, 100].freeze
+
+      SORT_OPTIONS =  [["relevance", "score desc, system_create_dtsi desc"], ["date uploaded ▼",
+        "system_create_dtsi desc"], ["date uploaded ▲", "system_create_dtsi asc"]].freeze
+
+      Facet_mappings = {
+        'resource_type_sim'  => 'Resource Type',
+        'institution_sim' => 'Institution',
+        'creator_search_sim' => 'Creator',
+        'keyword_sim' => 'Keyword',
+        'member_of_collections_ssim' => 'Collections'
+      }.freeze
+
+    end
+  end
+end

--- a/app/views/ubiquity/shared_search/_facet.html.erb
+++ b/app/views/ubiquity/shared_search/_facet.html.erb
@@ -1,0 +1,65 @@
+<div id="ajax-modal" class="ubiquity-facet-more modal fade in" tabindex="-1" role="dialog" aria-labelledby="modal menu" aria-hidden="true" style="display: block;">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <div class="facet_pagination top">
+        <div class="prev_next_links btn-group pull-left">
+          <!--
+          <span class="disabled btn btn-disabled">« Previous</span>
+
+          <span class="disabled btn  btn-disabled">Next »</span>
+          -->
+       </div>
+
+        <div class="sort_options btn-group pull-right">
+          <%# link_to 'A-Z Sort', shared_search_facet_path(more_field: @facet_key, locale: 'en', sort_change: 'numerical', q: cookies[:search_term] ), data: {'ajax-modal' => "preserve"}, class: "sort_change az btn btn-default", remote: true %>
+
+          <!--  <span class="active numeric btn btn-default">Numerical Sort</span> -->
+        </div>
+
+     </div>
+
+      <div class="modal-header">
+        <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
+
+         <h3 class="modal-title"> <%=  Ubiquity::SharedSearch::Facet_mappings[@facet_key] %> </h3>
+
+     </div>
+
+      <div class="modal-body">
+        <div class="facet_extended_list">
+           <ul class="facet-values list-unstyled">
+             <% @facet_more.each do |key, value| %>
+               <% if key == 'resource_type_sim' %>
+                 <li><span class="facet-label"> <%= link_to key, shared_search_index_path(f: {@facet_key.to_sym => key}, locale: 'en', q: cookies[:search_term] ), class: "facet_select" %> </span> <span class="facet-count"><%=  human_readable_resource_type([value]) %></span></li>
+               <% else %>
+                 <li><span class="facet-label"> <%= link_to key, shared_search_index_path(f: {@facet_key.to_sym => key}, locale: 'en', q: cookies[:search_term] ), class: "facet_select" %> </span> <span class="facet-count"><%= value %></span></li>
+               <% end %>
+             <% end %>
+           </ul>
+
+         </div>
+       </div>
+
+       <div class="modal-footer">
+
+         <div class="facet_pagination bottom">
+           <div class="prev_next_links btn-group pull-left">
+           <!--
+            <span class="disabled btn btn-disabled">« Previous</span>
+
+           <span class="disabled btn  btn-disabled">Next »</span>
+           -->
+           </div>
+
+           <div class="sort_options btn-group pull-right">
+            <%# link_to 'A-Z Sort', shared_search_facet_path(more_field: @facet_key, locale: 'en', sort_change: 'numerical', q: cookies[:search_term] ), data: {'ajax-modal' => "preserve"}, class: "sort_change az btn btn-default", remote: true %>
+            <!-- <span class="active numeric btn btn-default">Numerical Sort</span> -->
+           </div>
+
+         </div>
+      </div>
+
+   </div>
+  </div>
+</div>

--- a/app/views/ubiquity/shared_search/_facet_more.html.erb
+++ b/app/views/ubiquity/shared_search/_facet_more.html.erb
@@ -1,0 +1,60 @@
+<div class="col-xs-12">
+
+    <div class="facet_pagination top">
+  <div class="prev_next_links btn-group pull-left">
+
+    <span class="disabled btn btn-disabled">« Previous</span>
+
+
+    <span class="disabled btn  btn-disabled">Next »</span>
+</div>
+
+<div class="sort_options btn-group pull-right">
+    <a class="sort_change az btn btn-default" data-ajax-modal="preserve" href="/catalog/facet/resource_type_sim?facet.sort=index&amp;locale=en&amp;q=&amp;search_field=all_fields">A-Z Sort</a>
+    <span class="active numeric btn btn-default">Numerical Sort</span>
+</div>
+
+</div>
+
+<div class="modal-header">
+  <button type="button" class="ajax-modal-close close" data-dismiss="modal" aria-hidden="true">×</button>
+
+  <h3 class="modal-title">Resource type</h3>
+
+
+</div>
+<div class="modal-body">
+  <div class="facet_extended_list">
+  <ul class="facet-values list-unstyled">
+
+  <li><span class="facet-label"><a class="facet_select" href="/catalog?f%5Bresource_type_sim%5D%5B%5D=Article+default+Journal+article&amp;locale=en&amp;q=&amp;search_field=all_fields">Journal article</a></span><span class="facet-count" style="width: 8px;">3</span></li>
+
+<li><span class="facet-label"><a class="facet_select" href="/catalog?f%5Bresource_type_sim%5D%5B%5D=Collection+3D+image&amp;locale=en&amp;q=&amp;search_field=all_fields">3D image</a></span><span class="facet-count">1</span></li>
+
+<li><span class="facet-label"><a class="facet_select" href="/catalog?f%5Bresource_type_sim%5D%5B%5D=ConferenceItem+default+Conference+paper+%28unpublished%29&amp;locale=en&amp;q=&amp;search_field=all_fields">Conference paper (unpublished)</a></span><span class="facet-count">1</span></li>
+
+</ul>
+
+  </div>
+</div>
+
+<div class="modal-footer">
+
+  <div class="facet_pagination bottom">
+    <div class="prev_next_links btn-group pull-left">
+
+    <span class="disabled btn btn-disabled">« Previous</span>
+
+
+    <span class="disabled btn  btn-disabled">Next »</span>
+</div>
+
+<div class="sort_options btn-group pull-right">
+    <a class="sort_change az btn btn-default" data-ajax-modal="preserve" href="/catalog/facet/resource_type_sim?facet.sort=index&amp;locale=en&amp;q=&amp;search_field=all_fields">A-Z Sort</a>
+    <span class="active numeric btn btn-default">Numerical Sort</span>
+</div>
+
+  </div>
+</div>
+
+</div>

--- a/app/views/ubiquity/shared_search/_search_facet.html.erb
+++ b/app/views/ubiquity/shared_search/_search_facet.html.erb
@@ -1,0 +1,64 @@
+
+<% if @search_results.present? %>
+
+<div id="facets" class="facets sidenav">
+
+  <div class="top-panel-heading panel-heading">
+    <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
+      <span class="sr-only">Toggle facets</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+
+    <h2 class="facets-heading">
+      Limit your search
+    </h2>
+  </div>
+
+<div id="facet-panel-collapse" class="collapse panel-group">
+ <% facet_records.each do |key, hash| %>
+
+  <% display_key = Ubiquity::SharedSearch::Facet_mappings[key] %>
+
+  <div class="panel panel-default facet_limit blacklight-<%= key %>" >
+
+  <div class="collapsed collapse-toggle panel-heading" data-toggle="collapse" data-target="#facet-<%= key %>"  >
+    <h3 class="panel-title facet-field-heading">
+      <a data-no-turbolink="true" href="#"><%= display_key %></a>
+    </h3>
+  </div>
+
+   <div id="facet-<%= key %>" class="panel-collapse facet-content collapse">
+    <div class="panel-body">
+      <ul class="facet-values list-unstyled">
+        <% hash.each do |hash_key, hash_value| %>
+
+          <% if key == 'resource_type_sim' %>
+           <li><span class="facet-label">
+             <%= link_to  human_readable_resource_type([hash_key]),  shared_search_index_path(locale: 'en', per_page: cookies[:per_page], sort: cookies[:sort], q: cookies[:search_term], f: {key.to_sym => hash_key}), class: "facet_select" %>
+             </span> <span class="facet-count" style="width: 24px;">  <%= hash_value  %> </span>
+           </li>
+          <% else %>
+            <li><span class="facet-label">
+             <%= link_to  hash_key,  shared_search_index_path(locale: 'en', per_page: cookies[:per_page], sort: cookies[:sort], q: cookies[:search_term], f: {key.to_sym => hash_key}), class: "facet_select" %>
+              </span> <span class="facet-count" style="width: 24px;">  <%= hash_value %> </span>
+             </li>
+          <% end %>
+       <% end %>
+      </ul>
+
+      <%= link_to  'more »',  shared_search_facet_path(locale: 'en', sort: '', q: cookies[:search_term], more_field: key), remote: true, class: "more_facets_link" %>
+      <span class="sr-only"><%= display_key %> </span>
+
+    </div>
+  </div> <!-- closes facet-content -->
+
+  </div>
+
+  <% end %>
+</div> <!-- closes facet-panel -->
+
+</div> <!-- closes id=facets -->
+
+<% end %>

--- a/app/views/ubiquity/shared_search/_search_state.html.erb
+++ b/app/views/ubiquity/shared_search/_search_state.html.erb
@@ -1,7 +1,14 @@
 
+<% if @search.valid_json?(cookies[:facet]) %>
+  <% parsed_facet_cookie = JSON.parse(cookies[:facet]) %>
+<% else %>
+  <% parsed_facet_cookie = {} %>
+<% end %>
+
 <% search_term = cookies[:search_term] %>
 
-<% if search_term.present? %>
+<% if search_term.present? && parsed_facet_cookie.blank? %>
+
 <div id="appliedParams" class="clearfix constraints-container">
         <div class="pull-right">
           <a class="catalog_startOverLink btn btn-sm btn-text" id="startOverLink" href="/shared_search">Clear filters</a>
@@ -10,12 +17,60 @@
 
      <span class="btn-group appliedFilter constraint query">
        <span class="constraint-value btn btn-sm btn-default btn-disabled">
+         <span class="filterValue" title="<%= search_term %>"> <%= search_term %> </span>
+         <a class="btn btn-default btn-sm remove dropdown-toggle" href="/shared_search/destroy"><span class="glyphicon glyphicon-remove"></span><span class="sr-only">Remove constraint <%= search_term %> </span></a>
+      </span>
 
-       <span class="filterValue" title="<%= search_term %>"> <%= search_term %> </span>
-     </span>
-
-    <a class="btn btn-default btn-sm remove dropdown-toggle" href="/shared_search"><span class="glyphicon glyphicon-remove"></span><span class="sr-only">Remove constraint mola</span></a>
+   &nbsp;
 </span>
 
 </div>
+<% elsif parsed_facet_cookie.present? %>
+
+<div id="appliedParams" class="clearfix constraints-container">
+      <div class="pull-right">
+        <a class="catalog_startOverLink btn btn-sm btn-text" id="startOverLink" href="/shared_search">Clear filters</a>
+      </div>
+    <span class="constraints-label">Filtering by:</span>
+    <% if search_term.present? %>
+
+     <span class="btn-group appliedFilter constraint query">
+       <span class="constraint-value btn btn-sm btn-default btn-disabled">
+         <span class="filterValue" title="<%= search_term %>"> <%= search_term %> </span> &nbsp;
+
+         <%= link_to shared_search_destroy_path, class: "btn btn-default btn-sm remove dropdown-toggle" do %>
+            <span class="glyphicon glyphicon-remove"></span>
+             <span class="sr-only">Remove constraint <%= search_term %> </span>
+         <% end %>
+        </span>
+       </span> &nbsp;
+    <% end %>
+
+
+  <% parsed_facet_cookie.each do |key, value| %>
+
+    <% display_key = Ubiquity::SharedSearch::Facet_mappings[key] %>
+
+     <span class="btn-group appliedFilter  constraint filter filter-<%= value %> ">
+       <span class="constraint-value btn btn-sm btn-default btn-disabled">
+         <% if key == 'resource_type_sim' %>
+           <span class="filterName"> <%= display_key %> </span>
+           <span class="filterValue" title="<%= value %>"> <%= human_readable_resource_type([value]) %> </span> &nbsp;
+
+         <% else %>
+           <span class="filterName"> <%= display_key %> </span>
+           <span class="filterValue" title="<%= value %>"> <%= value %> </span> &nbsp;
+         <% end %>
+
+         <%= link_to shared_search_destroy_path(f: {key.to_sym => value}), class: "btn btn-default btn-sm remove dropdown-toggle" do %>
+            <span class="glyphicon glyphicon-remove"></span>
+            <span class="sr-only">Remove constraint <%= value %> </span>
+          <% end %>
+
+       </span>
+     </span>  &nbsp;
+     <% end %>
+
+</div>
+
 <% end %>

--- a/app/views/ubiquity/shared_search/_shared_search_form.html.erb
+++ b/app/views/ubiquity/shared_search/_shared_search_form.html.erb
@@ -1,13 +1,17 @@
 
 <% cookies.delete(:search_term) unless request.original_fullpath.include? 'shared_search' %>
-<% value = cookies[:search_term]  %>
+<% search_value = cookies[:search_term]  %>
 
 <div class="container-fluid">
   <div class="row">
     <div class="searchbar-right navbar-right col-sm-7 col-md-8">
-      <%= form_with url: '/shared_search', local: true, class: 'form-inline',  method: :get do |form| %>
+      <%= form_with url: '/shared_search', local: true, class: 'shared-search-form form-inline',  method: :get do |form| %>
           <div class="input-group">
-            <%= form.text_field :q,  value: value, class: "q form-control input-md", size: '80', placeholder: 'Search across all our repositories' %>
+            <%= form.text_field :q,  value: search_value, class: "q form-control input-md", size: '80', placeholder: 'Search across all our repositories' %>
+
+            <%= form.hidden_field :sort, value: cookies[:sort] %>
+            <%= form.hidden_field :per_per_page, value: cookies[:per_page] %>
+            <%# form.hidden_field :f,  value: cookies[:facet] %>
             <div class="input-group-btn">
               <button id="search-submit-header" class="btn btn-primary" type="submit">
                 <span class="glyphicon glyphicon-search"></span>

--- a/app/views/ubiquity/shared_search/facet.html.erb
+++ b/app/views/ubiquity/shared_search/facet.html.erb
@@ -1,0 +1,1 @@
+<%= render 'facet' %>

--- a/app/views/ubiquity/shared_search/facet.js.erb
+++ b/app/views/ubiquity/shared_search/facet.js.erb
@@ -1,0 +1,1 @@
+$("#ajax-modal").html("<%= escape_javascript(render partial: 'facet') %>")

--- a/app/views/ubiquity/shared_search/index.html.erb
+++ b/app/views/ubiquity/shared_search/index.html.erb
@@ -7,7 +7,9 @@
 
 <div class="container-fluid id="search-results"">
   <div class="row">
-    <div class="col-md-3"><!-- facet sidebar --> </div>
+    <div id="sidebar" class="col-md-3 col-sm-4"><!-- facet sidebar -->
+      <%= render 'search_facet', facet_records: @facet_records  %>
+    </div>
       <div  class="col-md-9">
         <div id="search-results">
           <ol style="list-style-type:none" class="catalog" start="1">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,9 @@ Rails.application.routes.draw do
   scope :module => "ubiquity" do
     resources :shared_search, only: [:index]
   end
+  get '/shared_search/facet/:more_field', to: 'ubiquity/shared_search#facet', as: 'shared_search_facet'
+  get '/shared_search/destroy', to: 'ubiquity/shared_search#destroy'
+
   mount BrowseEverything::Engine => '/browse'
   resource :site, only: [:update] do
     resources :roles, only: [:index, :update]
@@ -72,9 +75,9 @@ Rails.application.routes.draw do
         get :export_remap_model
         get :export_model
       end
-    end
+  end
 
-    resource :account, only: [:edit, :update]
+   resource :account, only: [:edit, :update]
     resources :users, only: [:destroy]
     resources :groups do
       member do

--- a/lib/tasks/ubiquity_work_reindex.rake
+++ b/lib/tasks/ubiquity_work_reindex.rake
@@ -1,0 +1,16 @@
+#run from  the terminal with and the rake task takes one argument
+# Note the tenant name is supplied when running the rake task, for example
+# if the tenant name is 'sandbox.repo-test.ubiquity.press', you will pass it as shown below
+#for example if the tenant cname is 'sandbox.repo-test.ubiquity.press' run as shown below
+# rake ubiquity_work_reindex:update['sandbox.repo-test.ubiquity.press']
+
+
+namespace :ubiquity_work_reindex do
+  desc "Reindex all works when necessary"
+
+  task :update, [:name] => :environment do |task, tenant|
+    cname = tenant[:name]
+    AccountElevator.switch!("#{cname}")
+    ActiveFedora::Base.reindex_everything
+  end
+end


### PR DESCRIPTION
https://trello.com/c/1l589TsD/460-7-search-across-all-repositories-from-the-shared-layer-faceted-browse

           Pre-deployment task

Add the following environment variables to allow for the facet list and the number items to show before clicking more to be configurable without redeployment:

     BL_SHARED_SEARCH_FACETS:   'resource_type_sim,creator_search_sim,institution_sim'
     BL_SHARED_SEARCH_FACETS_SIZE:   '5'

After deployment  or post deployment run the command below for each of the tenant to reindex the whole works again because the indexing that occurred when the works were created did not include the institution metadata field as a faceted field. but now we do :

    rake ubiquity_work_reindex:update['sandbox.repo-test.ubiquity.press']
   rake ubiquity_work_reindex:update['sandbox2.repo-test.ubiquity.press']