### PR TITLE
contact form honey-pot implementation

### DIFF
--- a/app/controllers/concerns/ubiquity/contact_form_controller_override.rb
+++ b/app/controllers/concerns/ubiquity/contact_form_controller_override.rb
@@ -1,0 +1,24 @@
+# Defined in https://github.com/samvera/hyrax/blob/v2.0.2/app/forms/hyrax/forms/batch_edit_form.rb
+module Ubiquity
+
+  module ContactFormControllerOverride
+    include ActiveSupport::Concern
+
+    def create
+    # not spam and a valid form
+      if @contact_form.valid?
+        Hyrax::ContactMailer.contact(@contact_form).deliver_now unless params["bot_catch"].present?
+        flash.now[:notice] = 'Thank you for your message!'
+        after_deliver unless params["bot_catch"].present?
+        @contact_form = Hyrax::ContactForm.new
+      else
+        flash.now[:error] = 'Sorry, this message was not sent successfully. '
+        flash.now[:error] << @contact_form.errors.full_messages.map(&:to_s).join(", ")
+      end
+      render :new
+      rescue RuntimeError => exception
+      handle_create_exception(exception)
+    end
+
+ end
+end

--- a/app/views/shared/ubiquity/contact/_new.html.erb
+++ b/app/views/shared/ubiquity/contact/_new.html.erb
@@ -31,6 +31,8 @@
     </div>
   </div>
 
+  <input type="text" name="bot_catch" style="display:none !important" tabindex="-1" autocomplete="off">
+
   <div class="form-group">
     <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
     <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,7 @@ module Hyku
       Hyrax::Forms::CollectionForm.prepend(::Ubiquity::CollectionFormBehaviour)
       Hyrax::Forms::BatchEditForm.prepend(::Ubiquity::AdditionalBatchEdit)
       Hyrax::FileSetDerivativesService.prepend(::Ubiquity::FilesetDerivativesServiceOverride)
+      Hyrax::ContactFormController.prepend(::Ubiquity::ContactFormControllerOverride)
     end
 
     config.before_initialize do


### PR DESCRIPTION
Resolves: https://trello.com/c/dTpXu67U/492-1-add-recaptcha-to-contact-form