### PR TITLE
"shared-search fix sort by relevance, and display of facet_more modal to match what is listed in facet list

### DIFF
--- a/app/controllers/ubiquity/shared_search_controller.rb
+++ b/app/controllers/ubiquity/shared_search_controller.rb
@@ -27,7 +27,6 @@ module Ubiquity
       if  params["f"].present?
         hash =   helpers.turn_params_facet_to_hash
         cookie_hash = remove_facet_cookie(hash.keys.first)
-        #return redirect_to shared_search_index_url(f: nil, q: cookies[:search_term]) if cookie_hash.blank?
         redirect_to shared_search_index_url(per_page: cookies[:per_page], sort: cookies[:sort], f: cookies[:facet], q: cookies[:search_term])
       else
         remove_search_term_cookie
@@ -51,7 +50,6 @@ module Ubiquity
       elsif (params["q"].present?  &&  cookies[:facet].present?) || (params[:sort].present? && get_facet_hash.present?)  || (params[:per_page].present? && get_facet_hash.present?)
         add_search_term_cookie(params["q"])
         set_facet_cookie
-        puts "cooker"
         return @search.combined_filter_query(params["q"], helpers.facet_cookie_to_hash) if params[:q].present?
         return @search.facet_filter_query(helpers.facet_cookie_to_hash) if params[:q].blank?
       elsif  params["q"].present?
@@ -119,9 +117,9 @@ module Ubiquity
       cookies.delete(:facet)
     end
 
-   def get_facet_hash
+    def get_facet_hash
       helpers.turn_params_facet_to_hash || helpers.facet_cookie_to_hash
-   end
+    end
 
   end
 end

--- a/app/services/ubiquity/shared_search.rb
+++ b/app/services/ubiquity/shared_search.rb
@@ -2,11 +2,11 @@
 #
 module Ubiquity
   class SharedSearch
-    #include Ubiquity::SharedSearchUtils
+    
     Hash_keys = ["system_create_dtsi", "id", "depositor_ssim", "title_tesim", "creator_search_tesim",
                 "creator_tesim",  "date_published_tesim", "resource_type_tesim", "account_cname_tesim",  "pagination_tesim", "institution_tesim",
                 "resource_type_tesim", "thumbnail_path_ss", "file_set_ids_ssim",
-                "visibility_ssi", "has_model_ssim" ].freeze
+                "visibility_ssi", "has_model_ssim", "score" ].freeze
 
     NAME_MAPPING = {
       "system_create_dtsi" => 'Date Created', "title_tesim" => 'Title',
@@ -89,7 +89,7 @@ module Ubiquity
     def combined_filter_query(search_term, filters)
       facet_query_terms = build_query_params_from_facet_values(filters)
       search_input = clean_and_downcase_user_search_term(search_term)
-      #changed from AND to OR because search term of darius and resource_type_sim dataset fails
+      #changed from AND to OR because search term eg darius and resource_type_sim dataset fails
       combined_terms = facet_query_terms.prepend("#{search_input} AND ")
       multiple_field_search(combined_terms, fields_to_search_against, 'multiple')
     end
@@ -140,9 +140,9 @@ module Ubiquity
         search_results << data.map {|hash| hash.slice(*Hash_keys)}
       end
       result = search_results.flatten.compact
-      return result.sort_by { |hash|[hash['system_create_dtsi'].to_date.strftime("%s").to_i, hash['score'] ]}.reverse if resort_search == 'relevance'
-      return result.sort_by { |hash| hash['system_create_dtsi'].to_date.strftime("%s").to_i} if resort_search == 'asc'
-      return result.sort_by { |hash| hash['system_create_dtsi'].to_date.strftime("%s").to_i}.reverse if resort_search == 'desc'
+      return result.sort_by { |hash|[hash['system_create_dtsi'], hash['score'] ]}.reverse if resort_search == 'relevance'
+      return result.sort_by { |hash| hash['system_create_dtsi']} if resort_search == 'asc'
+      return result.sort_by { |hash| hash['system_create_dtsi']}.reverse if resort_search == 'desc'
     end
 
     def multiple_field_search(search_term, query_fields, type='single')
@@ -159,13 +159,14 @@ module Ubiquity
            remap_facet_values(facet_data)
            #pull out the data from the response
            data =  search_response["response"]["docs"]
+
            #return only the desired hash keys
            search_results << data.map {|hash| hash.slice(*Hash_keys)}
          end
          result = search_results.flatten.compact
-         return result.sort_by { |hash|[hash['system_create_dtsi'].to_date.strftime("%s").to_i, hash['score'] ]}.reverse if resort_search == 'relevance'
-         return result.sort_by { |hash| hash['system_create_dtsi'].to_date.strftime("%s").to_i} if resort_search == 'asc'
-         return result.sort_by { |hash| hash['system_create_dtsi'].to_date.strftime("%s").to_i}.reverse if resort_search == 'desc'
+         return result.sort_by { |hash|[hash['system_create_dtsi'], hash['score'] ]}.reverse if resort_search == 'relevance'
+         return result.sort_by { |hash| hash['system_create_dtsi'] } if resort_search == 'asc'
+         return result.sort_by { |hash| hash['system_create_dtsi']}.reverse if resort_search == 'desc'
     end
 
     def sanitize_input(search_value)

--- a/app/views/ubiquity/shared_search/_search_facet.html.erb
+++ b/app/views/ubiquity/shared_search/_search_facet.html.erb
@@ -48,7 +48,7 @@
        <% end %>
       </ul>
 
-      <%= link_to  'more »',  shared_search_facet_path(locale: 'en', sort: '', q: cookies[:search_term], more_field: key), remote: true, class: "more_facets_link" %>
+      <%= link_to  'more »',  shared_search_facet_path(locale: 'en', sort: '', q: cookies[:search_term], more_field: key, f: facet_cookie_to_hash), remote: true, class: "more_facets_link" %>
       <span class="sr-only"><%= display_key %> </span>
 
     </div>

--- a/app/views/ubiquity/shared_search/_shared_search_form.html.erb
+++ b/app/views/ubiquity/shared_search/_shared_search_form.html.erb
@@ -1,8 +1,8 @@
 
 <% cookies.delete(:search_term) unless request.original_fullpath.include? 'shared_search' %>
 <% cookies.delete(:facet) unless request.original_fullpath.include? 'shared_search' %>
-<% cookies.delete(:sort) unless (request.original_fullpath.include? 'shared_search' || params['q'].present?) %>
-<% cookies.delete(:per_page) unless (request.original_fullpath.include? 'shared_search' || params['q'].present?) %>
+<% cookies[:sort]  = "score desc, system_create_dtsi desc"  unless (request.original_fullpath.include? 'shared_search' || params['q'].present?) %>
+<% cookies[:per_page] = 10 unless (request.original_fullpath.include? 'shared_search' || params['q'].present?) %>
 
 <% search_value = cookies[:search_term]  %>
 
@@ -14,7 +14,7 @@
             <%= form.text_field :q,  value: search_value, class: "q form-control input-md", size: '80', placeholder: 'Search across all our repositories' %>
 
             <%= hidden_field_tag :sort,  cookies[:sort] %>
-            <%= hidden_field_tag :per_per_page, cookies[:per_page] %>
+            <%= hidden_field_tag :per_page, cookies[:per_page] %>
             <div class="input-group-btn">
               <button id="search-submit-header" class="btn btn-primary" type="submit">
                 <span class="glyphicon glyphicon-search"></span>


### PR DESCRIPTION
Addresses the following trello cards:

https://trello.com/c/V8ThsGkQ/102-100-beta2-58-2-enable-search-across-all-repositories-from-the-shared-layer-search-navigation
https://trello.com/c/UphxjrFD/527-shared-search-where-there-is-a-text-search-already-and-a-facet-is-added-removed-then-the-number-of-records-per-page-is-reset-to