### PR TITLE
Added the exception catch in Wrapper API if the key is not present

### DIFF
--- a/app/services/ubiquity/importer_client.rb
+++ b/app/services/ubiquity/importer_client.rb
@@ -11,7 +11,7 @@ module Ubiquity
     def initialize(response)
       if response
         @file_status_hash = Hash[response['works'].map { |ele| [ele['uuid'], ele['status']] }]
-        @file_url_hash = Hash[response['works'].map { |ele| [ele['uuid'], ele['providers']['S3Storage']['link']] }]
+        @file_url_hash = Hash[response['works'].map { |ele| [ele['uuid'], ele['providers'].try(:fetch, 'S3Storage', '').try(:fetch, 'link')] }]
       else
         @file_status_hash = {}
         @file_url_hash = {}


### PR DESCRIPTION
Bug Fix for the S3 url api call, handling the exception if the S3 Storage hash is not present in the API call 