### PR TITLE
Added routes to download the file from s3 without exposing the url

### DIFF
--- a/app/controllers/ubiquity/fail_uploads_controller.rb
+++ b/app/controllers/ubiquity/fail_uploads_controller.rb
@@ -8,6 +8,14 @@ module Ubiquity
       end
     end
 
+    def download_file
+      params[:fileset_id]
+      uuid = params[:uuid]
+      s3_file_set_url = Ubiquity::ImporterClient.get_s3_url uuid
+      url = s3_file_set_url.file_url_hash[params[:fileset_id]]
+      redirect_to url
+    end
+
     private
 
       def uploaded_file_params

--- a/app/helpers/ubiquity/file_display_helpers.rb
+++ b/app/helpers/ubiquity/file_display_helpers.rb
@@ -49,7 +49,8 @@ module Ubiquity
         if @file_set_s3_object.file_url_hash[file_set_presenter.id].present?
           status = @file_set_s3_object.file_status_hash[file_set_presenter.id]
           if status == "UPLOAD_COMPLETED"
-            link_to 'Download', @file_set_s3_object.file_url_hash[file_set_presenter.id].to_s
+            # link_to 'Download', @file_set_s3_object.file_url_hash[file_set_presenter.id].to_s
+            link_to 'Download', main_app.fail_uploads_download_file_path(uuid: uuid, fileset_id: file_set_presenter.id), method: 'post'
           else
             "<a style='text-decoration:none;' href='#' onclick='return false;'>Upload In-Progress</a>".html_safe
           end
@@ -58,8 +59,6 @@ module Ubiquity
         end
       end
     end
-
-
 
     #receives a file_set when called from views/hyrax/base/_representative_media.html.erb
     #receives a Hyku::FileSetPresenter when called from views/shared/ubiquity/works/_member.html.erb

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
 
   # Fail Uploads Controller route
   get '/fail_uploads/delete_file' => 'ubiquity/fail_uploads#delete_file'
+  post '/fail_uploads/download_file' => 'ubiquity/fail_uploads#download_file'
 
   mount BrowseEverything::Engine => '/browse'
   resource :site, only: [:update] do


### PR DESCRIPTION
Fixed: https://trello.com/c/wNbtQhj8/540-s3-download-mask-amazon-url-as-much-as-possible

S3 url masking

- Added new routes for the donwloading
- Triggered the api call in the action with the corresponding FileSet id
- Redirect the action with the s3 url