### PR TITLE
modal for datacite rendering from form progress

### DIFF
--- a/app/views/admin/groups/edit.html.erb
+++ b/app/views/admin/groups/edit.html.erb
@@ -6,5 +6,4 @@
   </h1>
 <% end %>
 <%= render 'nav' %>
-<%= render 'ubiquity/external_services/datacite_modal' %>
 <%= render 'form' %>

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -1,5 +1,6 @@
 <% draft_doi = f.object.model.draft_doi %>
 <br>
+
 <div class='margin-adjustment-doi-option'>
   <aside id="form-progress" class="form-progress panel panel-default">
     <div class="panel-heading">
@@ -80,5 +81,6 @@
       </div>
     </div>
   </div>
+<%= render 'ubiquity/external_services/datacite_modal' %>
 
 </aside>

--- a/app/views/hyrax/base/new.html.erb
+++ b/app/views/hyrax/base/new.html.erb
@@ -4,5 +4,4 @@
   <h1><%= t("hyrax.works.create.header", type: curation_concern.human_readable_type) %></h1>
 <% end %>
 <%= render 'shared/ubiquity/datacite_doi' %>
-<%= render 'ubiquity/external_services/datacite_modal' %>
 <%= render 'form' %>

--- a/app/views/ubiquity/external_services/_datacite_modal.html.erb
+++ b/app/views/ubiquity/external_services/_datacite_modal.html.erb
@@ -2,7 +2,7 @@
 <!-- Rendered in app/views/hyrax/base/new.html.erb
                  app/views/admin/groups/edit.html.erb-->
 
-<div id="doi-options-modal" class="modal fade modal-year-validation" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" >
+<div id="doi-options-modal" class="modal fade modal-year-validation" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" data-backdrop="false">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
Modal for datacite rendering from form progress to restore correct functionality of the modal.
This pull request does not address the issue of model overlapping with institution field.