### PR TITLE
fix to allow universal viewer to work on sandbox

### DIFF
--- a/app/helpers/ubiquity/file_display_helpers.rb
+++ b/app/helpers/ubiquity/file_display_helpers.rb
@@ -14,7 +14,7 @@ module Ubiquity
          '<span class="center-block fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>'
       elsif ((check_file_is_restricted?(file_set_presenter) == nil) && (file_set_presenter.lease_expiration_date.present?) && (file_set_presenter.embargo_release_date.present?) )
         '<span class="center-block fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>'
-      elsif ((check_file_is_restricted?(file_set_presenter) == true) || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.visibility == "open") )
+      elsif ((check_file_is_restricted?(file_set_presenter) == true) || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") )
         #displays for logged out users on files without embargo/lease
         #also displays for logged_in users on files with embargo/lease
         render_thumbnail_tag(file_set_presenter)

--- a/app/views/shared/ubiquity/_thumbnail_featured.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_featured.html.erb
@@ -17,7 +17,7 @@
   <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
 <% elsif (check_file_is_restricted?(file_set_presenter) == nil && (file_set_presenter.lease_expiration_date.present?) && (file_set_presenter.embargo_release_date.present?)) %>
   <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
-<% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.visibility == "open") ) %>
+<% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") ) %>
    <% set_featured_img_size(document) %>
   <%= render_thumbnail_tag(document, {width: 90, class: 'hidden-xs file_listing_thumbnail'}, {suppress_link: true}) %>
 <% else %>

--- a/app/views/shared/ubiquity/_thumbnail_icons_with_restrictions.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_icons_with_restrictions.html.erb
@@ -17,7 +17,7 @@
   <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
 <% elsif (check_file_is_restricted?(file_set_presenter) == nil && (file_set_presenter.lease_expiration_date.present?) && (file_set_presenter.embargo_release_date.present?)) %>
   <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
-<% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.visibility == "open") ) %>
+<% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") ) %>
   <%= render_thumbnail_tag(document, {width: 90, class: 'hidden-xs file_listing_thumbnail'}, {suppress_link: true}) %>
 <% else %>
  <!-- displays for logged out users on files with embargo/lease

--- a/app/views/shared/ubiquity/file_sets/_restricted_media.html.erb
+++ b/app/views/shared/ubiquity/file_sets/_restricted_media.html.erb
@@ -8,7 +8,7 @@
   <% elsif check_file_is_restricted?(file_set_presenter) && presenter.representative_presenter.image? && (not zipped_types.include? check_file_extension(file_set_presenter.label)) %>
     <%= UniversalViewer.script_tag %>
     <div class="viewer-wrapper"><div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter] %>"></div></div>
-  <% elsif (  (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.visibility == "open") ) %>
+  <% elsif (  (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") ) %>
     <%= UniversalViewer.script_tag %>
     <div class="viewer-wrapper"><div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter] %>"></div></div>
   <% end %>


### PR DESCRIPTION
Attempt to fix an issue which causes sandbox to crash. To check for visibility we no use
`file_set_presenter.solr_document['visibility_ssi'] == "open"`