### PR TITLE
allow to send updates to datacite

### DIFF
--- a/app/models/concerns/ubiquity/work_doi_lifecycle.rb
+++ b/app/models/concerns/ubiquity/work_doi_lifecycle.rb
@@ -2,9 +2,9 @@ module Ubiquity
   module WorkDoiLifecycle
     extend ActiveSupport::Concern
 
-    attr_accessor :previous_work_visibility
     included do
-      after_create :post_to_indexer_if_doi_work_visibility_changed
+      attr_accessor :previous_work_visibility
+      after_save :post_to_indexer_if_doi_work_visibility_changed
     end
 
 
@@ -15,7 +15,7 @@ module Ubiquity
       external_service = ExternalService.where(draft_doi: self.draft_doi).first
       status_code = external_service.data['status_code'] if external_service.present?
       #called for new record and updating of old record where visibility_changed is true
-      if doi_enabled? && status_code != 201 && self.visibility == 'open' && (self.doi_options == 'Mint DOI:Registered' || self.doi_options == 'Mint DOI:Findable')
+      if doi_enabled? && self.visibility == 'open' && (self.doi_options == 'Mint DOI:Registered' || self.doi_options == 'Mint DOI:Findable')
         puts "Post to indexer #{self.id}"
         UbiquityPostToIndexerJob.perform_later(self.id, self.draft_doi)
       end


### PR DESCRIPTION
Resolved: https://trello.com/c/IvybTs67/538-datacite-when-editing-a-work-if-findable-or-registered-then-send-to-datacite-on-save-even-if-it-has-been-sent-before