### PR TITLE
Added License manipulation for crossreg and Datacite

### DIFF
--- a/app/services/ubiquity/crossref_response.rb
+++ b/app/services/ubiquity/crossref_response.rb
@@ -31,8 +31,11 @@ module Ubiquity
       return nil if attributes['license'].blank?
       url_array = fetch_url_from_response.split('/')
       url_collection = Hyrax::LicenseService.new.select_active_options.map(&:last)
-      regex_url = %r{(?:http|https):\/\/(?:www.|)(#{url_array[-4]})\/(#{url_array[-3]})\/(#{url_array[-2]})\/(#{url_array[-1]})}
-      url_collection.select { |e| e =~ regex_url }.first
+      rurl_array.pop if url_array.last == 'legalcode'
+      url_array.shift(2) # Removing the http, https and // part in the url
+      regex_url_str = "(?:http|https)://" + url_array.map { |ele| "(#{ele})" }.join('/')
+      regex_url_exp = Regexp.new regex_url_str
+      url_collection.select { |e| e.match regex_url_exp }.first
     end
 
 

--- a/app/services/ubiquity/datacite_client.rb
+++ b/app/services/ubiquity/datacite_client.rb
@@ -54,6 +54,7 @@ module Ubiquity
       end
 
       def parse_url(url)
+        url = url.strip
         handle_client do
           uri = URI.parse(url)
           if (uri.scheme.present? &&  uri.host.present?)

--- a/app/services/ubiquity/datacite_response.rb
+++ b/app/services/ubiquity/datacite_response.rb
@@ -27,7 +27,15 @@ module Ubiquity
     end
 
     def license
-      attributes.dig('license')
+      if attributes.dig('license').present?
+        url_array = attributes.dig('license').split('/')
+        url_collection = Hyrax::LicenseService.new.select_active_options.map(&:last)
+        url_array.pop if url_array.last == 'legalcode'
+        url_array.shift(2) # Removing the http, https and // part in the url
+        regex_url_str = "(?:http|https)://" + url_array.map { |ele| "(#{ele})" }.join('/')
+        regex_url_exp = Regexp.new regex_url_str
+        url_collection.select { |e| e.match regex_url_exp }.first
+      end
     end
 
     def doi
@@ -63,7 +71,7 @@ module Ubiquity
       fields << 'DOI' if doi.present?
       fields << 'Related Identifier' if related_identifier.present?
       fields << 'Abstract' if abstract.present?
-      fields << 'Licence' if (license.present? && licence_present?.include?(license))
+      fields << 'Licence' if license.present?
       # fields << 'version' if version.present?
 
       "The following fields were auto-populated - #{fields.to_sentence}"


### PR DESCRIPTION
Fixes https://trello.com/c/1KqT5Xoe/442-datacite-auto-populate-manipulate-the-incoming-licence-in-3-ways-to-match-the-licence-that-is-in-the-data-model

Added Regular Expression matching the url response with the data client URL's
