### PR TITLE
Highlight fields based on ui

### DIFF
--- a/app/assets/javascripts/ubiquity/datacite.js
+++ b/app/assets/javascripts/ubiquity/datacite.js
@@ -83,8 +83,8 @@ function fetchDataciteData(url) {
           populateKeyword(result.data.keyword)
         }
         //IE11 will not show the ,message when .val() is used hence .html()
-        var str = "The following fields were auto-populated " + field_array.slice(0, field_array.length - 1).join(', ') + ", and " + field_array.slice(-1);
-        $(".ubiquity-fields-populated").html(str)
+        var message = "The following fields were auto-populated " + field_array.slice(0, field_array.length - 1).join(', ') + ", and " + field_array.slice(-1);
+        $(".ubiquity-fields-populated").html(message)
         $(".ubiquity-fields-populated").show()
       } else {
         $(".ubiquity-fields-populated-error").html(result.data.error)
@@ -96,7 +96,7 @@ function fetchDataciteData(url) {
 
 function populateRelatedIdentifierValues(relatedArray){
   $.each(relatedArray, function(key, value){
-      addValues(key, value);
+    addValues(key, value);
   })
 }
 
@@ -108,7 +108,7 @@ function populateKeyword(keywordArray){
 
 function addKeywordValues(key, value){
   if (key == 0) {
-  $(".ubiquity-keyword:last").val(value)
+    $(".ubiquity-keyword:last").val(value)
   }
   else{
     var parent_li = $(".ubiquity-keyword:last").parent();
@@ -140,7 +140,7 @@ function addValues(key, value) {
 
 function populateCreatorValues(creatorArray){
   $.each(creatorArray, function(key, value){
-      addCreatorValues(key, value);
+    addCreatorValues(key, value);
   })
 }
 

--- a/app/assets/javascripts/ubiquity/datacite.js
+++ b/app/assets/javascripts/ubiquity/datacite.js
@@ -14,30 +14,77 @@ function fetchDataciteData(url) {
   var host = window.document.location.host;
   var protocol = window.document.location.protocol;
   var fullHost = protocol + '//' + host + '/available_ubiquity_titles/call_datasite';
+  var field_array = [];
   $.ajax({
     url: fullHost,
     type: "POST",
     data: {"url": url},
     success: function(result){
       if (result.data.error  === undefined) {
-        $(".ubiquity-title").val(result.data.title)
-        $('.ubiquity-abstract').val(result.data.abstract)
-        $('.ubiquity-doi').val(result.data.doi)
+        if($('.ubiquity-title').length != 0 && result.data.title != null) {
+          $(".ubiquity-title").val(result.data.title)
+          field_array.push('Title')
+        }
+        if ($('.ubiquity-abstract').length != 0 && result.data.abstract != null) {
+          field_array.push('Abstract')
+          $('.ubiquity-abstract').val(result.data.abstract)
+        }
+        if($('.ubiquity-doi').length != 0 && result.data.doi != null) {
+          field_array.push('DOI')
+          $('.ubiquity-doi').val(result.data.doi)
+        }
         //populate dropdown
-        $('.ubiquity-date-published-year').val(result.data.published_year);
-        $('.ubiquity-date-published-month').val(result.data.published_month);
-        $('.ubiquity-date-published-day').val(result.data.published_day);
-        $('.ubiquity-license').val(result.data.license);
-        $('.ubiquity-issn').val(result.data.issn);
-        $('.ubiquity-journal-title').val(result.data.journal_title);
-        $('.ubiquity-eissn').val(result.data.eissn);
-        $('.ubiquity-isbn').val(result.data.isbn);
-        $('.ubiquity-publisher').val(result.data.publisher);
-        populateRelatedIdentifierValues(result.data.related_identifier_group)
-        populateCreatorValues(result.data.creator_group)
-        populateKeyword(result.data.keyword)
+        if($('.ubiquity-date-published-year').length != 0 && result.data.published_year != null) {
+          field_array.push('Published Year')
+          $('.ubiquity-date-published-year').val(result.data.published_year);
+        }
+        if($('.ubiquity-date-published-month').length != 0 && result.data.published_month != null) {
+          field_array.push('Published Month')
+          $('.ubiquity-date-published-month').val(result.data.published_month);
+        }
+        if($('.ubiquity-date-published-day').length != 0 && result.data.published_day != null) {
+          field_array.push('Published Day')
+          $('.ubiquity-date-published-day').val(result.data.published_day);
+        }
+        if($('.ubiquity-license').length != 0 && result.data.license != null) {
+          field_array.push('Licence')
+          $('.ubiquity-license').val(result.data.license);
+        }
+        if($('.ubiquity-issn').length != 0 && result.data.issn != null) {
+          field_array.push('ISSN')
+          $('.ubiquity-issn').val(result.data.issn);
+        }
+        if($('.ubiquity-journal-title').length != 0 && result.data.journal_title != null) {
+          field_array.push('Journal Title')
+          $('.ubiquity-journal-title').val(result.data.journal_title);
+        }
+        if($('.ubiquity-eissn').length != 0 && result.data.eissn != null) {
+          field_array.push('eISSN')
+          $('.ubiquity-eissn').val(result.data.eissn);
+        }
+        if($('.ubiquity-isbn').length != 0 && result.data.isbn != null) {
+          field_array.push('ISBN')
+          $('.ubiquity-isbn').val(result.data.isbn);
+        }
+        if($('.ubiquity-publisher').length != 0 && result.data.publisher != null) {
+          field_array.push('Publisher')
+          $('.ubiquity-publisher').val(result.data.publisher);
+        }
+        if ($(".ubiquity-meta-related-identifier") != 0 && result.data.related_identifier_group != null) {
+          field_array.push('Related Identifier')
+          populateRelatedIdentifierValues(result.data.related_identifier_group)
+        }
+        if ($(".ubiquity-meta-creator").length != 0 && result.data.creator_group != null) {
+          field_array.push('Creator')
+          populateCreatorValues(result.data.creator_group)
+        }
+        if ($(".ubiquity-keyword").length != 0 && result.data.keyword != null) {
+          field_array.push('Keyword')
+          populateKeyword(result.data.keyword)
+        }
         //IE11 will not show the ,message when .val() is used hence .html()
-        $(".ubiquity-fields-populated").html(result.data.auto_populated)
+        var str = "The following fields were auto-populated " + field_array.slice(0, field_array.length - 1).join(', ') + ", and " + field_array.slice(-1);
+        $(".ubiquity-fields-populated").html(str)
         $(".ubiquity-fields-populated").show()
       } else {
         $(".ubiquity-fields-populated-error").html(result.data.error)
@@ -61,7 +108,7 @@ function populateKeyword(keywordArray){
 
 function addKeywordValues(key, value){
   if (key == 0) {
-   $(".ubiquity-keyword:last").val(value)
+  $(".ubiquity-keyword:last").val(value)
   }
   else{
     var parent_li = $(".ubiquity-keyword:last").parent();
@@ -71,7 +118,6 @@ function addKeywordValues(key, value){
     $(".ubiquity-keyword:last").val(value);
   }
 }
-
 
 function addValues(key, value) {
 

--- a/app/services/ubiquity/crossref_response.rb
+++ b/app/services/ubiquity/crossref_response.rb
@@ -109,27 +109,6 @@ module Ubiquity
       attributes['license'].first['URL']
     end
 
-    # def auto_populated_fields
-    #   fields = []
-    #   fields << 'Title' if title.present?
-    #   fields << 'Creator' if creator.present?
-    #   fields << "Published year" if date_published_year.present?
-    #   fields << "Published month" if date_published_month.present?
-    #   fields << "Published day" if date_published_day.present?
-    #   fields << 'DOI' if doi.present?
-    #   fields << 'Journal Title' if journal_title.present?
-    #   fields << 'ISSN' if issn.present?
-    #   fields << 'eISSN' if eissn.present?
-    #   fields << 'Abstract' if abstract.present?
-    #   fields << 'Keyword' if keyword.present?
-    #   fields << 'ISBN' if isbn.present?
-    #   fields << 'Licence' if license.present?
-    #   fields << 'Publisher' if publisher.present?
-    #   # fields << 'version' if version.present?
-
-    #   "The following fields were auto-populated - #{fields.to_sentence}"
-    # end
-
     def data
       if error.present?
         { 'error' => error }

--- a/app/services/ubiquity/crossref_response.rb
+++ b/app/services/ubiquity/crossref_response.rb
@@ -106,26 +106,26 @@ module Ubiquity
       attributes['license'].first['URL']
     end
 
-    def auto_populated_fields
-      fields = []
-      fields << 'Title' if title.present?
-      fields << 'Creator' if creator.present?
-      fields << "Published year" if date_published_year.present?
-      fields << "Published month" if date_published_month.present?
-      fields << "Published day" if date_published_day.present?
-      fields << 'DOI' if doi.present?
-      fields << 'Journal Title' if journal_title.present?
-      fields << 'ISSN' if issn.present?
-      fields << 'eISSN' if eissn.present?
-      fields << 'Abstract' if abstract.present?
-      fields << 'Keyword' if keyword.present?
-      fields << 'ISBN' if isbn.present?
-      fields << 'Licence' if license.present?
-      fields << 'Publisher' if publisher.present?
-      # fields << 'version' if version.present?
+    # def auto_populated_fields
+    #   fields = []
+    #   fields << 'Title' if title.present?
+    #   fields << 'Creator' if creator.present?
+    #   fields << "Published year" if date_published_year.present?
+    #   fields << "Published month" if date_published_month.present?
+    #   fields << "Published day" if date_published_day.present?
+    #   fields << 'DOI' if doi.present?
+    #   fields << 'Journal Title' if journal_title.present?
+    #   fields << 'ISSN' if issn.present?
+    #   fields << 'eISSN' if eissn.present?
+    #   fields << 'Abstract' if abstract.present?
+    #   fields << 'Keyword' if keyword.present?
+    #   fields << 'ISBN' if isbn.present?
+    #   fields << 'Licence' if license.present?
+    #   fields << 'Publisher' if publisher.present?
+    #   # fields << 'version' if version.present?
 
-      "The following fields were auto-populated - #{fields.to_sentence}"
-    end
+    #   "The following fields were auto-populated - #{fields.to_sentence}"
+    # end
 
     def data
       if error.present?
@@ -137,7 +137,7 @@ module Ubiquity
           issn: issn, eissn: eissn, journal_title: journal_title,
           abstract: abstract, version: version, isbn: isbn,
           creator_group: creator, doi: doi, keyword: keyword, license: license,
-          auto_populated: auto_populated_fields, publisher: publisher
+          publisher: publisher
         }
       end
     end

--- a/app/services/ubiquity/datacite_response.rb
+++ b/app/services/ubiquity/datacite_response.rb
@@ -55,19 +55,19 @@ module Ubiquity
       end
     end
 
-    def auto_populated_fields
-      fields = []
-      fields << 'Title' if title.present?
-      fields << 'Creator' if creator.present?
-      fields << "Published" if date_published_year.present?
-      fields << 'DOI' if doi.present?
-      fields << 'Related Identifier' if related_identifier.present?
-      fields << 'Abstract' if abstract.present?
-      fields << 'Licence' if (license.present? && licence_present?.include?(license))
-      # fields << 'version' if version.present?
+    # def auto_populated_fields
+    #   fields = []
+    #   fields << 'Title' if title.present?
+    #   fields << 'Creator' if creator.present?
+    #   fields << "Published" if date_published_year.present?
+    #   fields << 'DOI' if doi.present?
+    #   fields << 'Related Identifier' if related_identifier.present?
+    #   fields << 'Abstract' if abstract.present?
+    #   fields << 'Licence' if (license.present? && licence_present?.include?(license))
+    #   # fields << 'version' if version.present?
 
-      "The following fields were auto-populated - #{fields.to_sentence}"
-    end
+    #   "The following fields were auto-populated - #{fields.to_sentence}"
+    # end
 
     def data
       if error.present?
@@ -78,7 +78,6 @@ module Ubiquity
           "title": title, "published_year": date_published_year,
           "abstract": abstract, "version": version,
           "creator_group": creator, "license": license,
-          "auto_populated": auto_populated_fields,
           "doi": doi
         }
       end

--- a/app/services/ubiquity/datacite_response.rb
+++ b/app/services/ubiquity/datacite_response.rb
@@ -63,20 +63,6 @@ module Ubiquity
       end
     end
 
-    # def auto_populated_fields
-    #   fields = []
-    #   fields << 'Title' if title.present?
-    #   fields << 'Creator' if creator.present?
-    #   fields << "Published" if date_published_year.present?
-    #   fields << 'DOI' if doi.present?
-    #   fields << 'Related Identifier' if related_identifier.present?
-    #   fields << 'Abstract' if abstract.present?
-    #   fields << 'Licence' if (license.present? && licence_present?.include?(license))
-    #   # fields << 'version' if version.present?
-
-    #   "The following fields were auto-populated - #{fields.to_sentence}"
-    # end
-
     def data
       if error.present?
         { 'error' => error }
@@ -91,7 +77,7 @@ module Ubiquity
       end
     end
 
-     private
+    private
 
       def creator_without_seperated_names(data)
         new_group = data.map {|hash| hash['literal']}
@@ -123,13 +109,5 @@ module Ubiquity
         end
         new_creator_group
       end
-
-    #fetches list licences from config/authorities/licenses.yml
-    # returns each record in the form of ["CC BY 4.0 Attribution", "https://creativecommons.org/licenses/by/4.0/"]
-    # we are returning just the last part eg [ "https://creativecommons.org/licenses/by/4.0/"]
-    def licence_present?
-      licences = Hyrax::LicenseService.new.select_all_options
-      licences.map(&:last)
-    end
   end
 end


### PR DESCRIPTION
Fixes: https://trello.com/c/h79c3NH8/552-crossref-pre-population-highlight-which-fields-have-been-populated-only-if-they-are-in-the-ui-deposit-form

Removed the message string module from the Response class and Integrated in the JS code in-order to check if the element is present in the DOM.