### PR TITLE
fix issue of private icon file notdisplaying for logged out user on s…

### DIFF
--- a/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
+++ b/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
@@ -1,11 +1,10 @@
 
-<%# Hyrax::ModelIcon.css_class_for(Collection) for adding font-awesome cube icon%>
 <% if document.thumbnail_id %>
   <div class="list-thumbnail">
 
     <% presenter = Hyku::ManifestEnabledWorkShowPresenter.new(document, current_ability) %>
     <% file_set_presenter = presenter.thumbnail_presenter %>
-    <%# file_set_presenter.inspect %>
+
     <% if file_set_presenter.present? %>
       <% if zipped_types.include? check_file_extension(file_set_presenter.solr_document.label) %>
         <span class="fa fa-file-archive-o fa-5x grey-zip-icon" style="color:grey;padding-left:60px"></span>
@@ -15,10 +14,10 @@
         <span class="fa fa-file-word-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:60px"></span> <span style="padding-left:125px"></span>
       <% elsif (document.thumbnail_path.split('?').last == "file=thumbnail") && ([".docx", '.doc', '.pdf'].exclude? check_file_extension(file_set_presenter.solr_document.label)) && (zipped_types.exclude? check_file_extension(file_set_presenter.solr_document.label) )   %>
         <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:60px"></span> <span style="padding-left:125px"></span>
-      <% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.solr_document.lease_expiration_date.present?) && (not file_set_presenter.solr_document.embargo_release_date.present?) ) %>
-        <%= render_thumbnail_tag document, :style => "width:150px;padding-left:25px" %>
-      <% elsif (check_file_is_restricted?(file_set_presenter) == nil && (file_set_presenter.lease_expiration_date.present? || file_set_presenter.embargo_release_date.present?) ) %>
+      <% elsif (check_file_is_restricted?(file_set_presenter) == nil && (file_set_presenter.lease_expiration_date.present? || file_set_presenter.embargo_release_date.present? || ( file_set_presenter.solr_document['visibility_ssi'] == "restricted") ) ) %>
         <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:60px"></span> <span style="padding-left:125px"></span>
+     <% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.solr_document.lease_expiration_date.present?) && (not file_set_presenter.solr_document.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") ) %>
+        <%= render_thumbnail_tag document, :style => "width:150px;padding-left:25px" %>
       <% end %>
     <% else %>
       <%# displays for logged out user for files under embargo/lease %>


### PR DESCRIPTION
Resolves: https://trello.com/c/B8ozDYGH/539-bug-private-and-presumably-embargo-files-on-public-works-are-showing-the-thumbnail-on-homepage-featured-latest-search-results-an