### PR TITLE
change the order of call backs to allow for a doi to be show in the s…

### DIFF
--- a/app/models/concerns/ubiquity/track_doi_options.rb
+++ b/app/models/concerns/ubiquity/track_doi_options.rb
@@ -5,8 +5,8 @@ module Ubiquity
 
     included do
       before_save :set_disable_draft_doi
-      before_save :set_doi
       before_save :autocreate_draft_doi
+      before_save :set_doi
       before_save :set_manual_doi
     end
 


### PR DESCRIPTION
Resolves: https://trello.com/c/mBA0GElf/555-datacite-workflow-issue-on-show-work-page-show-the-doi-as-soon-as-it-is-present-in-the-data