### PR TITLE
add solr relevance score and work creation to date to frontend of  new-shared-search display

### DIFF
--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,7 +1,4 @@
-<h2>
-    <% model = document.to_h %>
-    <% url = generate_work_url(model['id'], model["account_cname_tesim"].try(:first), model["has_model_ssim"].first, request.host, request.protocol, request.port) %>
-    <%= link_to model["title_tesim"].first, url %>
-    <!-- please dont remove yet-->
-    <%# link_to document.title_or_label, document %>
-</h2>
+
+<!-- copied from https://github.com/samvera/hyrax/blob/v2.0.2/app/views/catalog/_index_header_list_default.html.erb -->
+
+<%= render "shared/ubiquity/catalog/index_header_list_default", document: document %>

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -1,37 +1,6 @@
 <%# This is a Blacklight file copied to Hyrax by Hyrax maintainers and then copied here from Hyrax
     hyrax/app/views/catalog/_index_list_default.html.erb to add ability to display json metadata fields  %>
-<div class="metadata">
-  <table class="table">
-    <% doc_presenter = index_presenter(document) %>
 
-    <% index_fields(document).each_with_index do |(field_name, field), index| %>
+<!-- this partial is called in app/views/catalog/_index_list_default.html.erb -->
 
-      <% if should_render_index_field? document, field %>
-        <tr>
-        <% if ["creator_tesim", "contributor_tesim" , "editor_tesim"].include? field_name %>
-          <th class="search-meta-label"><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
-          <td><%= display_json_fields(document, field_name) %></td>
-        <% elsif check_is_parent_shared_search_page.present? && field_name == 'institution_tesim' %>
-          <th class="search-meta-label"><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
-          <td><%= document.institution.sort.to_sentence %></td>
-        <% elsif field_name != 'institution_tesim'  %>
-          <th class="search-meta-label"><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
-          <td><%= doc_presenter.field_value field_name %></td>
-        <% end %>
-        </tr>
-      <% end %>
-
-    <% end %>
-      <tr>
-        <th class="search-meta-label"><span class="attribute-label h4"> Type: </span></th>
-        <% if document.to_h["has_model_ssim"].first == 'Collection' %>
-          <td><%= document.to_h["has_model_ssim"].first %></td>
-        <% else %>
-          <td>Work</td>
-        <% end %>
-      </tr>
-      
-  </table>
-</div>
-
-<div class="clearfix"></div>
+<%= render "shared/ubiquity/catalog/index_list_default", document: document  %>

--- a/app/views/shared/ubiquity/catalog/_index_header_list_default.html.erb
+++ b/app/views/shared/ubiquity/catalog/_index_header_list_default.html.erb
@@ -1,0 +1,10 @@
+<!-- copied from https://github.com/samvera/hyrax/blob/v2.0.2/app/views/catalog/_index_header_list_default.html.erb -->
+<!-- this partial is called in app/views/catalog/_index_header_list_default.html.erb -->
+
+<h2>
+    <% model = document.to_h %>
+    <% url = generate_work_url(model['id'], model["account_cname_tesim"].try(:first), model["has_model_ssim"].first, request.host, request.protocol, request.port) %>
+    <%= link_to model["title_tesim"].first, url %>
+    <!-- please dont remove yet-->
+    <%# link_to document.title_or_label, document %>
+</h2>

--- a/app/views/shared/ubiquity/catalog/_index_list_default.html.erb
+++ b/app/views/shared/ubiquity/catalog/_index_list_default.html.erb
@@ -15,7 +15,7 @@
 
         <% if check_is_parent_shared_search_page.present? && field_name == 'institution_tesim'  %>
           <th class="search-meta-label"><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
-          <td><%= document.institution.sort.to_sentence %></td>
+          <td><%= link_to_facet_list(document.institution.sort, 'institution', '', '; ').html_safe %></td>
         <% end %>
 
         <% if ['resource_type_tesim', 'institution_tesim', "creator_tesim", "contributor_tesim" , "editor_tesim"].exclude? field_name %>

--- a/app/views/shared/ubiquity/catalog/_index_list_default.html.erb
+++ b/app/views/shared/ubiquity/catalog/_index_list_default.html.erb
@@ -1,0 +1,56 @@
+<%# This is a Blacklight file copied to Hyrax by Hyrax maintainers and then copied here from Hyrax
+    hyrax/app/views/catalog/_index_list_default.html.erb to add ability to display json metadata fields  %>
+<div class="metadata">
+  <table class="table">
+    <% doc_presenter = index_presenter(document) %>
+
+    <% index_fields(document).each_with_index do |(field_name, field), index| %>
+
+      <% if should_render_index_field? document, field %>
+        <tr>
+        <% if ["creator_tesim", "contributor_tesim" , "editor_tesim"].include? field_name %>
+          <th class="search-meta-label"><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
+          <td><%= display_json_fields(document, field_name) %></td>
+        <% end %>
+
+        <% if check_is_parent_shared_search_page.present? && field_name == 'institution_tesim'  %>
+          <th class="search-meta-label"><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
+          <td><%= document.institution.sort.to_sentence %></td>
+        <% end %>
+
+        <% if ['resource_type_tesim', 'institution_tesim', "creator_tesim", "contributor_tesim" , "editor_tesim"].exclude? field_name %>
+          <th class="search-meta-label"><span class="attribute-label h4"><%= render_index_field_label document, field: field_name %></span></th>
+          <td><%= doc_presenter.field_value field_name %></td>
+        <% end %>
+
+        </tr>
+      <% end %>
+
+      <% if field_name == 'resource_type_tesim'  %>
+        <tr>
+         <th class="search-meta-label"><span class="attribute-label h4"> <%= render_index_field_label document, field: field_name %> </span></th>
+         <% if document.to_h["has_model_ssim"].first == 'Collection' %>
+         <td><%= document.to_h["has_model_ssim"].first %></td>
+         <% else %>
+         <td><%= doc_presenter.field_value field_name %></td>
+        <% end %>
+         </tr>
+       <% end %>
+
+    <% end %>
+
+      <% if ['localhost', 'repo-test'].any? { |name| name.in?(request.original_url)} %>
+      <tr>
+        <th class="search-meta-label"><span class="attribute-label h4"> Debug Date Created: </span></th>
+        <td><%= DateTime.parse(document.to_h["system_create_dtsi"]) %></td>
+      </tr>
+        <tr>
+          <th class="search-meta-label"><span class="attribute-label h4"> Score: </span></th>
+          <td> <%= document.to_h['score'] %> </td>
+        </tr>
+       <% end %>
+
+  </table>
+</div>
+
+<div class="clearfix"></div>


### PR DESCRIPTION
Resolves the following cards:

https://trello.com/c/pJVgZkz8/558-shared-search-show-resource-type-as-collection-in-search-results-if-it-is-a-collection

https://trello.com/c/AE4kY6XB/559-shared-search-replace-commas-between-institution-names-with-semi-colons-and-remove-and-before-last-institution