### PR TITLE
Added book title and the collection in the display form

### DIFF
--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -14,7 +14,7 @@ module Hyrax
     #version is used in the show page but populated by version_number from the edit and new form
     self.terms += %i[title resource_type creator contributor rendering_ids abstract date_published media
                      institution org_unit project_name funder fndr_project_ref event_title event_location event_date
-                     series_name editor journal_title volume edition version_number issue pagination article_num
+                     series_name book_title editor journal_title volume edition version_number issue pagination article_num
                      publisher place_of_publication isbn issn eissn date_accepted date_submitted official_link
                      related_url related_exhibition related_exhibition_date language license rights_statement
                      rights_holder doi draft_doi alternate_identifier related_identifier refereed keyword

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,6 +1,9 @@
 <%# display contributor using the show partial  -->
 <%# presenter.attribute_to_html(:contributor, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :resource_type) %>
+<% if presenter.member_of_collection_presenters.present?%>
+  <%= render 'shared/ubiquity/collections/show_collection_list', presenter: presenter %>
+<%end%>
 <%= render "shared/ubiquity/creator/show", presenter: presenter %>
 <%= render "shared/ubiquity/contributor/show", presenter: presenter %>
 <%= presenter.attribute_to_html(:abstract, render_as: :string) %>

--- a/app/views/shared/ubiquity/collections/_show_collection_list.html.erb
+++ b/app/views/shared/ubiquity/collections/_show_collection_list.html.erb
@@ -1,0 +1,10 @@
+<tr>
+  <th>Collections</th>
+  <td>
+    <ul class="tabular">
+      <% presenter.member_of_collection_presenters.each do |p| %>
+        <li class='attribute'><%= link_to p.to_s, hyrax.collection_path(p.id), class: 'collection-link' %></li>
+      <% end %>
+    </ul>
+  </td>
+</tr>

--- a/app/views/shared/ubiquity/collections/_show_collection_list.html.erb
+++ b/app/views/shared/ubiquity/collections/_show_collection_list.html.erb
@@ -1,3 +1,5 @@
+<!-- copied from https://github.com/samvera/hyrax/blob/master/app/views/hyrax/base/_member_of_collections.html.erb
+-->
 <tr>
   <th>Collections</th>
   <td>


### PR DESCRIPTION
Fixes: https://trello.com/c/J60aM5UO/563-add-book-title-in-the-generic-work-form-and-add-collection-row-in-the-display-form-for-all-the-works-if-present
 
- Added Book Title field in the work show page
- Added collection row in the work show page
