### PR TITLE
change the check for deleting the work pop up message

### DIFF
--- a/app/assets/javascripts/ubiquity/external_services_modal.js
+++ b/app/assets/javascripts/ubiquity/external_services_modal.js
@@ -37,11 +37,11 @@
       var doiOptions = $('ul.doi_option_list input:checked').val();
       var visibilityCheck = (visibility == "open" || visibility == "embargo")
       var doiOptionsCheck = (doiOptions == "Mint DOI:Registered" || doiOptions == "Mint DOI:Findable")
-      //conditions to be met to show modal window
       $("#doi-options-modal").on("click", "#modal_button_save", function() {
         $('#doi-options-modal').modal('hide');
         $('.simple_form').submit();
       });
+      //conditions to be met to show modal window
       if (visibilityCheck && doiOptionsCheck) {
         $('#doi-options-modal').modal('show');
         e.preventDefault();

--- a/app/helpers/ubiquity/work_show_actions_helper.rb
+++ b/app/helpers/ubiquity/work_show_actions_helper.rb
@@ -1,12 +1,18 @@
 module Ubiquity::WorkShowActionsHelper
 
   def delete_pop_up_message(presenter)
-     official_link = presenter.solr_document["official_link_tesim"]
-     if official_link.present? == true
+     if work_status_code(presenter.solr_document.id) == 200
        link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Warning: This #{presenter.human_readable_type} has a live DOI. Deleting the work will cause the DOI to lead to a non-existent page." }, method: :delete
      else
        link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete
      end
+  end
+
+  private
+
+  def work_status_code(work_id)
+    work = ExternalService.where(work_id: work_id).first
+    work['data']['status_code'] if work
   end
 
 end


### PR DESCRIPTION
Add a change to previous pr where now the delete message will change its content checking against the value of status code.
Resolves: https://trello.com/c/UfZCJ9y8/570-add-additional-check-to-message-validation-when-user-deletes-a-work-with-live-doi