### PR TITLE
Renamed the generic work name in the pop up modal

### DIFF
--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -4,7 +4,7 @@ en:
       generic_work:     'fa fa-file-text-o'
     select_type:
       generic_work:
-        name:               "General Purpose Work Type"
+        name:               "Generic Work"
         description:        "General purpose work type. Select this if the more specific work types below are not suited to the work you want to add."
   simple_form:
     hints:


### PR DESCRIPTION
Fixes: Renaming the Generic Work Type text in the Deposit pop up modal