### PR TITLE
escaped the invalid url characters to url friendly

### DIFF
--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -165,6 +165,8 @@ module Ubiquity
     def remove_hash_keys_with_empty_and_nil_values(data)
       if (data.present? && data.class == Array)
         new_data = data.map do |hash|
+          hash['creator_orcid'] = URI.parse(CGI.escape(hash['creator_orcid'].squish)) if hash['creator_orcid'].present?
+          hash['creator_isni'] = URI.parse(CGI.escape(hash['creator_isni'].squish)) if hash['creator_isni'].present?
           hash.reject { |k,v| v.nil? || v.to_s.empty? || v == "NaN"}
         end
         # remove hash that contains only default keys and values.


### PR DESCRIPTION
Fixes https://trello.com/c/KD8PBgok/571-when-manipulating-the-isni-field-and-orcid-on-save-pay-attention-to-backslash-and-tabs

Added escaping special characters in the Orcid and Isni value under creator group