### PR TITLE
Fixed the thumbnail issue in the file sets and the work listing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,10 +60,17 @@ module ApplicationHelper
   end
 
   # For image thumbnails, override the default size for a better resolution on homepage
-  def render_related_img(solr_doc)
-    img_path = solr_doc['thumbnail_path_ss'].presence || ['/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png']
-    img_path = img_path.split('!150,300').join(',600') if img_path.include?('!150,300')
-    image_tag img_path
+  def render_related_img(doc)
+    solr_doc = FileSet.find(doc.id)
+    img_path = CGI.escape(ActiveFedora::File.uri_to_id(solr_doc.original_file.versions.last.uri))
+    # img_path = solr_doc['thumbnail_path_ss'].presence || ['/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png']
+    image_tag "#{img_path}/full/150,120/0/default.jpg"
+  end
+
+  def render_thumbnail_on_list(file_set)
+    solr_doc = FileSet.find(file_set.id)
+    img_path = CGI.escape(ActiveFedora::File.uri_to_id(solr_doc.original_file.versions.last.uri))
+    image_tag "#{img_path}/full/100,80/0/default.jpg"
   end
 
   def verify_valid_json?(data)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,10 +67,10 @@ module ApplicationHelper
     image_tag "#{img_path}/full/150,120/0/default.jpg"
   end
 
-  def render_thumbnail_on_list(file_set)
+  def render_thumbnail_on_list(file_set, size = '100,80')
     solr_doc = FileSet.find(file_set.id)
     img_path = CGI.escape(ActiveFedora::File.uri_to_id(solr_doc.original_file.versions.last.uri))
-    image_tag "#{img_path}/full/100,80/0/default.jpg"
+    image_tag "#{img_path}/full/#{size}/0/default.jpg"
   end
 
   def verify_valid_json?(data)

--- a/app/helpers/ubiquity/file_display_helpers.rb
+++ b/app/helpers/ubiquity/file_display_helpers.rb
@@ -1,9 +1,9 @@
 module Ubiquity
   module FileDisplayHelpers
 
-    #called in app/views/shared/ubiquity/works/_member.html.erb and app/views/shared/ubiquity/file_sets/_media_display.html.erb
+    # called in app/views/shared/ubiquity/works/_member.html.erb and app/views/shared/ubiquity/file_sets/_media_display.html.erb
     def render_file_or_icon(file_set_presenter)
-      #displays zip icon for files with archived format eg zi
+      # displays zip icon for files with archived format eg zi
       if zipped_types.include?  check_file_extension(file_set_presenter.label)
         '<span class="center-block fa fa-file-archive-o fa-5x grey-zip-icon"></span>'
       elsif (check_file_extension(file_set_presenter.label) == ".pdf") && (file_set_presenter.solr_document.thumbnail_path.split('?').last == "file=thumbnail")
@@ -11,16 +11,16 @@ module Ubiquity
       elsif ([".docx", '.doc'].include? check_file_extension(file_set_presenter.label)) && (file_set_presenter.solr_document.thumbnail_path.split('?').last == "file=thumbnail")
         '<span class="center-block fa fa-file-word-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>'
       elsif (file_set_presenter.solr_document.thumbnail_path.split('?').last == "file=thumbnail") && ([".docx", '.doc', '.pdf'].exclude? check_file_extension(file_set_presenter.label)) && (zipped_types.exclude? check_file_extension(file_set_presenter.label) )
-         '<span class="center-block fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>'
+        '<span class="center-block fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>'
       elsif ((check_file_is_restricted?(file_set_presenter) == nil) && (file_set_presenter.lease_expiration_date.present?) && (file_set_presenter.embargo_release_date.present?) )
         '<span class="center-block fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>'
       elsif ((check_file_is_restricted?(file_set_presenter) == true) || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") )
-        #displays for logged out users on files without embargo/lease
-        #also displays for logged_in users on files with embargo/lease
-        render_thumbnail_tag(file_set_presenter)
+        # displays for logged out users on files without embargo/lease
+        # also displays for logged_in users on files with embargo/lease
+        render_related_img(file_set_presenter)
       else
-        #displays for logged out users on files with embargo/lease
-        #'<span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>'
+        # displays for logged out users on files with embargo/lease
+        # '<span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>'
         '<span class="center-block fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>'
       end
     end

--- a/app/presenters/concerns/displays_image.rb
+++ b/app/presenters/concerns/displays_image.rb
@@ -12,25 +12,26 @@ module DisplaysImage
     original_file = FileSet.find(id).original_file
 
     # TODO: We want url to be like https://libimages1.princeton.edu/loris/plum/0c%2F48%2F3j%2F48%2F8-intermediate_file.jp2/full/!200,200/0/default.jpg
-    url = display_image_url(original_file)
-    IIIFManifest::DisplayImage.new(url, width: 640, height: 480, iiif_endpoint: iiif_endpoint(original_file))
+    latest_file_uri = original_file.has_versions? ? ActiveFedora::File.uri_to_id(original_file.versions.last.uri) : original_file.uri.value
+    url = display_image_url(latest_file_uri)
+    IIIFManifest::DisplayImage.new(url, width: 640, height: 480, iiif_endpoint: iiif_endpoint(latest_file_uri))
   end
 
   private
 
-    def display_image_url(original_file, size = '600,')
-      Riiif::Engine.routes.url_helpers.image_url(original_file.id,
+    def display_image_url(original_file_uri, size = '600,')
+      Riiif::Engine.routes.url_helpers.image_url(original_file_uri,
                                                  host: request.base_url,
                                                  size: size)
     end
 
-    def base_image_url(original_file)
-      uri = Riiif::Engine.routes.url_helpers.info_url(original_file.id, host: request.base_url)
+    def base_image_url(original_file_uri)
+      uri = Riiif::Engine.routes.url_helpers.info_url(original_file_uri, host: request.base_url)
       # TODO: There should be a riiif route for this:
       uri.sub(%r{/info\.json\Z}, '')
     end
 
-    def iiif_endpoint(original_file)
-      IIIFManifest::IIIFEndpoint.new(base_image_url(original_file), profile: "http://iiif.io/api/image/2/level2.json")
+    def iiif_endpoint(original_file_uri)
+      IIIFManifest::IIIFEndpoint.new(base_image_url(original_file_uri), profile: "http://iiif.io/api/image/2/level2.json")
     end
 end

--- a/app/views/shared/ubiquity/_thumbnail_featured.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_featured.html.erb
@@ -19,7 +19,7 @@
   <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
 <% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") ) %>
    <% set_featured_img_size(document) %>
-  <%= render_thumbnail_tag(document, {width: 90, class: 'hidden-xs file_listing_thumbnail'}, {suppress_link: true}) %>
+  <%= render_thumbnail_on_list(file_set_presenter) %>
 <% else %>
  <!-- displays for logged out users on files with embargo/lease
   <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>

--- a/app/views/shared/ubiquity/_thumbnail_featured.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_featured.html.erb
@@ -19,7 +19,7 @@
   <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
 <% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") ) %>
    <% set_featured_img_size(document) %>
-  <%= render_thumbnail_on_list(file_set_presenter) %>
+  <%= render_thumbnail_on_list(file_set_presenter, '!360,360') %>
 <% else %>
  <!-- displays for logged out users on files with embargo/lease
   <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>

--- a/app/views/shared/ubiquity/_thumbnail_icons.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_icons.html.erb
@@ -14,5 +14,5 @@
 <% elsif (document.thumbnail_path.split('?').last == "file=thumbnail") && ([".docx", '.doc', '.pdf'].exclude? check_file_extension(file_set_presenter.solr_document.label)) && (zipped_types.exclude? check_file_extension(file_set_presenter.solr_document.label) )   %>
   <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey"></span>
 <% else %>
-  <%= render_thumbnail_tag document, { class: 'hidden-xs file_listing_thumbnail' }, { suppress_link: true } %>
+  <%=  render_thumbnail_on_list(file_set_presenter) %>
  <% end %>

--- a/app/views/shared/ubiquity/_thumbnail_icons_with_restrictions.html.erb
+++ b/app/views/shared/ubiquity/_thumbnail_icons_with_restrictions.html.erb
@@ -18,7 +18,7 @@
 <% elsif (check_file_is_restricted?(file_set_presenter) == nil && (file_set_presenter.lease_expiration_date.present?) && (file_set_presenter.embargo_release_date.present?)) %>
   <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:20px"></span> </span><span style="width:100px;padding-left:115px"></span>
 <% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.lease_expiration_date.present?) && (not file_set_presenter.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") ) %>
-  <%= render_thumbnail_tag(document, {width: 90, class: 'hidden-xs file_listing_thumbnail'}, {suppress_link: true}) %>
+  <%= render_thumbnail_on_list(file_set_presenter) %>
 <% else %>
  <!-- displays for logged out users on files with embargo/lease
   <span class="media-left hidden-xs file_listing_thumbnail mock-thumbnail" ></span>

--- a/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
+++ b/app/views/shared/ubiquity/search_display/_search_thumbnail.html.erb
@@ -17,7 +17,7 @@
       <% elsif (check_file_is_restricted?(file_set_presenter) == nil && (file_set_presenter.lease_expiration_date.present? || file_set_presenter.embargo_release_date.present? || ( file_set_presenter.solr_document['visibility_ssi'] == "restricted") ) ) %>
         <span class="fa fa-file-o fa-5x hidden-xs file_listing_thumbnail" style="color:grey;padding-left:60px"></span> <span style="padding-left:125px"></span>
      <% elsif (check_file_is_restricted?(file_set_presenter) == true || (not file_set_presenter.solr_document.lease_expiration_date.present?) && (not file_set_presenter.solr_document.embargo_release_date.present?) && ( file_set_presenter.solr_document['visibility_ssi'] == "open") ) %>
-        <%= render_thumbnail_tag document, :style => "width:150px;padding-left:25px" %>
+        <%= render_thumbnail_on_list(file_set_presenter) %>
       <% end %>
     <% else %>
       <%# displays for logged out user for files under embargo/lease %>


### PR DESCRIPTION
Fixes: https://trello.com/c/bcQ45rCV/577-loading-new-version-of-file-needs-to-be-possible-from-edit-file-page

Fixed the thumbnail by adding a custom helper method in the Application Helper and integrate the method in all the views.