### PR TITLE
Fixed the pop up message in the datatcite doi

### DIFF
--- a/app/assets/javascripts/ubiquity/external_services_modal.js
+++ b/app/assets/javascripts/ubiquity/external_services_modal.js
@@ -3,6 +3,10 @@
     var publicationYear = $('.ubiquity-date-published-year').val();
     var visibility = $('.set-access-controls ul.visibility li.radio input:checked').val();
     var doiOptions = $('ul.doi_option_list input:checked').val();
+    var doiOptionsCheck = (doiOptions == "Mint DOI:Registered" || doiOptions == "Mint DOI:Findable")
+    if (visibility === undefined){
+      visibility = $('#ubiquity_work_visibility').val();
+    }
     var draftDoi = $(".ubiquity-draft-doi").val()
     var doi = $(".ubiquity-doi").val()
     var officialLink = $(".ubiquity-official-link").val()
@@ -19,7 +23,7 @@
       var msg = 'Please note an updated record will be sent to DataCite, if you continue.'
       $('#modal_button_save').attr('disabled', false);
     }
-    else if (draftDoi !== '' && visibility == "embargo"){
+    else if (visibility == "embargo" && (draftDoi !== '' || doiOptionsCheck)){
       var msg = 'Please note that a DOI will be minted at DataCite on release of embargo, if you continue.'
       $('#modal_button_save').attr('disabled', false);
     }
@@ -34,6 +38,9 @@
     $('#with_files_submit').on('click', function(e) {
       messagesSwitcher();
       var visibility = $('.set-access-controls ul.visibility li.radio input:checked').val();
+      if (visibility === undefined){
+        visibility = $('#ubiquity_work_visibility').val();
+      }
       var doiOptions = $('ul.doi_option_list input:checked').val();
       var visibilityCheck = (visibility == "open" || visibility == "embargo")
       var doiOptionsCheck = (doiOptions == "Mint DOI:Registered" || doiOptions == "Mint DOI:Findable")

--- a/app/helpers/ubiquity/permission_badge_helper.rb
+++ b/app/helpers/ubiquity/permission_badge_helper.rb
@@ -1,0 +1,14 @@
+
+module Ubiquity
+  module PermissionBadgeHelper
+    def fetch_permission_badge(object)
+      if object.embargo_release_date.present?
+        'embargo'
+      elsif object.lease_expiration_date
+        'lease'
+      else
+        object.model.visibility
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -1,4 +1,5 @@
 <% draft_doi = f.object.model.draft_doi %>
+<%= hidden_field_tag :ubiquity_work_visibility, fetch_permission_badge(f.object)%>
 <br>
 
 <div class='margin-adjustment-doi-option'>


### PR DESCRIPTION
Fixes:

- https://trello.com/c/uQ9uyD86/588-doi-release-after-embargo-text-in-pop-up-window-is-dependent-on-whether-you-press-the-create-and-save-draft-doi-button
- https://trello.com/c/N9YSC57R/520-15830-datacite-doi-minting-hyku-sends-message-rest-post-to-indexer-api-to-confirm-that-a-doi-needs-to-be-minted-updated