### PR TITLE
removed debug and relevance score from search page

### DIFF
--- a/app/views/shared/ubiquity/catalog/_index_list_default.html.erb
+++ b/app/views/shared/ubiquity/catalog/_index_list_default.html.erb
@@ -39,17 +39,6 @@
 
     <% end %>
 
-      <% if ['localhost', 'repo-test'].any? { |name| name.in?(request.original_url)} %>
-        <tr>
-          <th class="search-meta-label"><span class="attribute-label h4"> Debug Date Created: </span></th>
-          <td><%= DateTime.parse(document.to_h["system_create_dtsi"]) %></td>
-        </tr>
-        <tr>
-          <th class="search-meta-label"><span class="attribute-label h4"> Debug Score: </span></th>
-          <td> <%= document.to_h['score'] %> </td>
-         </tr>
-       <% end %>
-
   </table>
 </div>
 


### PR DESCRIPTION
Resolved: https://trello.com/c/mrfSfBO0/590-remove-debug-date-created-and-relevance-score-from-search-results