### PR TITLE
Fixed the issue in the keyword in RIF template

### DIFF
--- a/app/controllers/concerns/ubiquity/citations_export_concern.rb
+++ b/app/controllers/concerns/ubiquity/citations_export_concern.rb
@@ -26,7 +26,7 @@ module Ubiquity
         end
         value = work.try(column)
         next if value.blank?
-        if ris_key == 'KY'
+        if ris_key == 'KW'
           value.each do |kw_value|
             rif_data_ary << "#{ris_key}  - #{kw_value}"
           end


### PR DESCRIPTION
Fixes : https://trello.com/c/piOtS2bg/476-v15924-5-enable-reference-management-tools-zotero-endnote-mendeley-to-read-and-export-work-metadata-via-ris-file-download

- Typo in the Keyword value