### PR TITLE
Stop adding workid to externalservice if it exist and change update to save after adding official_url in indexer client to allow re-indexing of work

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -117,6 +117,8 @@ class CatalogController < ApplicationController
     # config.add_index_field solr_name("identifier", :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
     config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
     config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
+    config.add_index_field solr_name("official_link", :stored_searchable), label: "Official link"
+
     # config.add_index_field solr_name("org_unit", :stored_searchable), label: "Organisational Unit"
     # config.add_index_field solr_name("funder", :stored_searchable), label: "Funder"
     # config.add_index_field solr_name("fndr_project_ref", :stored_searchable), label: "Funder project reference"

--- a/app/jobs/add_work_id_to_external_service_job.rb
+++ b/app/jobs/add_work_id_to_external_service_job.rb
@@ -5,9 +5,9 @@ class AddWorkIdToExternalServiceJob < ActiveJob::Base #ApplicationJob
   def perform(work_id, tenant_name)
     AccountElevator.switch!(tenant_name)
     work = ActiveFedora::Base.find(work_id)
-    if work.present?
-      exter = ExternalService.where(draft_doi: work.draft_doi)
+    exter = ExternalService.where(draft_doi: work.draft_doi).first
+    #if work.present? && exter.try(:work_id).present?
       exter.update(work_id: work.id)
-    end
+    #end
   end
 end

--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -24,7 +24,10 @@ module Ubiquity
     private
 
       def update_external_service_record
-        AddWorkIdToExternalServiceJob.perform_later(self.id, self.account_cname)
+        exter = ExternalService.where(draft_doi: self.draft_doi).first
+        if exter.try(:work_id).blank?
+          AddWorkIdToExternalServiceJob.perform_later(self.id, self.account_cname)
+        end
       end
 
       def create_work_service_if_embargo_or_lease

--- a/app/models/concerns/ubiquity/work_doi_lifecycle.rb
+++ b/app/models/concerns/ubiquity/work_doi_lifecycle.rb
@@ -12,17 +12,10 @@ module Ubiquity
 
     def post_to_indexer_if_doi_work_visibility_changed
       AccountElevator.switch!(self.account_cname)
-      external_service = ExternalService.where(draft_doi: self.draft_doi).first
-      status_code = external_service.data['status_code'] if external_service.present?
-      #called for new record and updating of old record where visibility_changed is true
-      if doi_enabled? && self.visibility == 'open' && (self.doi_options == 'Mint DOI:Registered' || self.doi_options == 'Mint DOI:Findable')
+      if doi_enabled? && self.visibility == 'open' && self.draft_doi && (self.doi_options == 'Mint DOI:Registered' || self.doi_options == 'Mint DOI:Findable')
         puts "Post to indexer #{self.id}"
         UbiquityPostToIndexerJob.perform_later(self.id, self.draft_doi, self.account_cname)
       end
-    end
-
-    def check_field_changes
-      self.visibility_changed? == true || self.doi_options_changed? == true
     end
 
     def doi_enabled?

--- a/app/services/ubiquity/indexer_client.rb
+++ b/app/services/ubiquity/indexer_client.rb
@@ -14,19 +14,10 @@ module Ubiquity
     def post
       service_code = ENV['SERVICE_CODE']
       body = {resource_type: resource_type, uuid: work_uuid, service_code: service_code}.to_json
-      puts"BODY#{body}"
       handle_client do
         response = self.class.post(api_path, body: body, headers: headers )
-        puts"CANADA#{response}"
-        puts"ACCOUNTELEVATOR#{ExternalService.find_by(draft_doi: draft_doi).inspect}"
         AccountElevator.switch!(tenant_name)
-        puts"BEFORE QUERY DRAFT_DOI#{draft_doi}"
-        puts"BEFORE QUERY DRAFT_DOI#{work_uuid}"
         external_service = ExternalService.find_by(draft_doi: draft_doi) || ExternalService.find_by(work_id: work_uuid)
-        puts"MADAGASCAR#{external_service}"
-        puts"AFTER QUERY DRAFT_DOI#{draft_doi}"
-        puts"AFTER QUERY UUID#{work_uuid}"
-        puts"ITALY#{@draft_doi}"
         external_service.try(:data)['status_code'] = response.code
         external_service.save
         set_official_url(work_uuid, response.code)
@@ -59,7 +50,12 @@ module Ubiquity
     def set_official_url(id, status_code)
       work = ActiveFedora::Base.find(id)
       if [201, 200].include? status_code
-        work.update(official_link: "https://doi.org/#{work.draft_doi}") if work.official_link.blank?
+        #work.update(official_link: "https://doi.org/#{work.draft_doi}") if work.official_link.blank?
+         if work.official_link.blank?
+          work.official_link = "https://doi.org/#{work.draft_doi}"
+          puts"TAKEAWAY #{work.official_link_changed?}"
+          work.save
+        end
       end
     end
 

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -34,3 +34,5 @@
     <%#= render 'user_activity', presenter: @presenter %>
   </div>
 </div>
+<br>
+Official Url Debug: <%= @presenter.official_link.inspect %>


### PR DESCRIPTION
Resolves: https://trello.com/c/D1BIMe49/515-15827-doi-minting-doi-suffix-is-auto-generated-and-appended-to-prefix-saved-in-a-new-draft-doi-field-that-is-not-displayed-publi