### PR TITLE
Displaying the file title instead of file label in the show page

### DIFF
--- a/app/views/shared/ubiquity/works/_member.html.erb
+++ b/app/views/shared/ubiquity/works/_member.html.erb
@@ -5,7 +5,7 @@
     <!--see app/helpers/ubiquity/file_display_helpers.rb -->
     <%= render_file_or_icon(member).html_safe %>
  </td>
-  <td class="attribute filename"><%= link_to(member.label, contextual_path(member, @presenter)) %></td>
+  <td class="attribute filename"><%= link_to(member.title.first, contextual_path(member, @presenter)) %></td>
   <td class="attribute date_uploaded"><%= member.try(:date_uploaded) %></td>
   <td class="attribute permission">
     <%= member.permission_badge %>


### PR DESCRIPTION
Fixes https://trello.com/c/bcQ45rCV/577-v15924-loading-new-version-of-file-needs-to-be-possible-from-edit-file-page-revert-before-release-to-live
 
Fixed the label in the file display page