### PR TITLE
allow file_availability rake task to be run per model by passing in the model and tenant name

### DIFF
--- a/app/models/concerns/ubiquity/update_shared_index.rb
+++ b/app/models/concerns/ubiquity/update_shared_index.rb
@@ -16,7 +16,7 @@ module Ubiquity
     private
 
     def add_record_to_index
-      shared_search_check =  get_account_tenant.settings['include_in_shared_search']
+      shared_search_check =  get_account_tenant && get_account_tenant.settings['include_in_shared_search']
       if parent_tenant.present? && shared_search_check == 'true'
         Ubiquity::SharedIndexSolrServiceWrapper.new(self.to_solr, 'add', parent_tenant, get_file_sets, shared_search_check).update
         #if you switch the tenant back to the one that owns the work, you will get a blacklight error rendering show
@@ -32,7 +32,9 @@ module Ubiquity
     end
 
     def get_account_tenant
-      @account ||=  Account.where(cname: self.account_cname).first
+      if self.account_cname.present?
+        @account ||=  Account.where(cname: self.account_cname).first
+      end
     end
 
     def parent_tenant

--- a/app/models/concerns/ubiquity/work_doi_lifecycle.rb
+++ b/app/models/concerns/ubiquity/work_doi_lifecycle.rb
@@ -11,7 +11,8 @@ module Ubiquity
     private
 
     def post_to_indexer_if_doi_work_visibility_changed
-      AccountElevator.switch!(self.account_cname)
+      puts "Did not post to indexer because account_came is nil"  if self.account_cname.blank?
+      AccountElevator.switch!(self.account_cname) if self.account_cname.present?
       if doi_enabled? && self.visibility == 'open' && self.draft_doi && (self.doi_options == 'Mint DOI:Registered' || self.doi_options == 'Mint DOI:Findable')
         puts "Post to indexer #{self.id}"
         Ubiquity::IndexerClient.new(self.id, self.draft_doi, self.account_cname).post
@@ -20,12 +21,14 @@ module Ubiquity
     end
 
     def doi_enabled?
-      tenant_name = self.account_cname.split('.').first
-      tenant_json = ENV["TENANTS_SETTINGS"]
-      tenant_hash = JSON.parse(tenant_json) if is_valid_json?(tenant_json)
-      feature_hash = JSON.parse(ENV['FEATURE_ENABLED']) if is_valid_json?(ENV['FEATURE_ENABLED'])
-      if tenant_hash.present? && feature_hash.present? && tenant_hash[tenant_name]['datacite_prefix'].present?
-        (feature_hash['doi_option'] == 'true') && (tenant_hash[tenant_name]['ENABLE_DOI'] == "true")
+      if self.account_cname.present?
+        tenant_name = self.account_cname.split('.').first
+        tenant_json = ENV["TENANTS_SETTINGS"]
+        tenant_hash = JSON.parse(tenant_json) if is_valid_json?(tenant_json)
+        feature_hash = JSON.parse(ENV['FEATURE_ENABLED']) if is_valid_json?(ENV['FEATURE_ENABLED'])
+        if tenant_hash.present? && feature_hash.present? && tenant_hash[tenant_name]['datacite_prefix'].present?
+          (feature_hash['doi_option'] == 'true') && (tenant_hash[tenant_name]['ENABLE_DOI'] == "true")
+        end
       end
     end
 

--- a/lib/tasks/ubiquity_index_file_availability_facet.rake
+++ b/lib/tasks/ubiquity_index_file_availability_facet.rake
@@ -2,6 +2,8 @@
 # Note the tenant name is supplied when running the rake task, for example
 # if the tenant name is 'sandbox.repo-test.ubiquity.press', you will pass it as shown below
 # rake ubiquity_index_file_availability_facet:update['sandbox.repo-test.ubiquity.press']
+#for updatinga specific model note the surrounding string after the rake command
+# rake "ubiquity_index_file_availability_facet:update_specific_model[sandbox.repo-test.ubiquity.press,  generic_work]"
 
 namespace :ubiquity_index_file_availability_facet do
   desc "Run this task to popolate the file_availability field for existing works"
@@ -17,13 +19,24 @@ namespace :ubiquity_index_file_availability_facet do
          #by calling save we trigger the before_save callback in app/models/ubiquity/concerns/multiple_modules.rb
           model_instance.save
           sleep 2
-
-          #to avoid lossing the current tenant in account elevator switch, since another switch
-          #happens after save when indexing to shared searh, hence the need to switch back
-          AccountElevator.switch!("#{tenant[:name]}")
       end
     end
+  end
 
+  task :update_specific_model, [:tenant_name, :model_name] => :environment do |task, args|
+    tenant_name = args[:tenant_name]
+    puts "tenant_cname in file_availability rake task: #{tenant_name}"
+    AccountElevator.switch!(tenant_name)
+    model = args[:model_name]
+    model_class = model.to_s.classify.constantize
+    puts "model_name  in file_availability rake task: #{model_class}"
+
+    model_class.find_each do |model_instance|
+      puts "model_id in in file_availability rake task:   #{model_instance.id}"
+       #by calling save we trigger the before_save callback in app/models/ubiquity/concerns/multiple_modules.rb
+      model_instance.save
+      sleep 2
+    end
   end
 
 end


### PR DESCRIPTION
https://trello.com/c/fTpzGNZV/450-v15929-update-filters-to-include-facet-by-file-availability-switched-off

####### Run it with 
rake "ubiquity_index_file_availability_facet:update_specific_model[library.localhost,  generic_work]"

###### Dont  run it like this 
rake ubiquity_index_file_availability_facet:update_specific_model[library.localhost,  generic_work]

fails with 
Don't know how to build task 'ubiquity_index_file_availability_facet:update_specific_model[library.localhost,' (see --tasks)