### PR TITLE
Add language missing field in article form

### DIFF
--- a/app/forms/hyrax/article_form.rb
+++ b/app/forms/hyrax/article_form.rb
@@ -7,7 +7,7 @@ module Hyrax
     self.terms += %i[title alt_title resource_type creator contributor abstract date_published institution
                      org_unit project_name funder fndr_project_ref journal_title alternative_journal_title volume issue pagination
                      article_num publisher place_of_publication issn eissn date_accepted date_submitted
-                     official_link related_url license rights_statement rights_holder doi draft_doi
+                     official_link related_url language license rights_statement rights_holder doi draft_doi
                      alternate_identifier related_identifier refereed keyword dewey library_of_congress_classification
                      add_info rendering_ids
                     ]


### PR DESCRIPTION
Fixes: https://trello.com/c/U1AjYOyX/610-missing-language-field-in-article-deposit-form