### PR TITLE
return object or empty hash in rescue when block  to_solr fails in file_set indexer when running  file_availability rake task

### DIFF
--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -9,6 +9,6 @@ class FileSetIndexer < Hyrax::FileSetIndexer
   rescue Ldp::HttpError => exception
      puts "exception is: #{exception.inspect}"
      puts "calling to_solr on fileset failed #{object.inspect}"
-
+     object || {}
   end
 end

--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -9,6 +9,6 @@ class FileSetIndexer < Hyrax::FileSetIndexer
   rescue Ldp::HttpError => exception
      puts "exception is: #{exception.inspect}"
      puts "calling to_solr on fileset failed #{object.inspect}"
-     object || {}
+     object 
   end
 end

--- a/app/models/concerns/ubiquity/update_shared_index.rb
+++ b/app/models/concerns/ubiquity/update_shared_index.rb
@@ -4,6 +4,8 @@ module Ubiquity
 
     included do
       after_save :add_record_to_index, on: [:create, :update]
+      after_save :get_file_sets, on: [:create, :update]
+
       before_destroy :remove_record_from_index
 
       before_save :get_collection_child_records
@@ -18,7 +20,7 @@ module Ubiquity
     def add_record_to_index
       shared_search_check =  get_account_tenant && get_account_tenant.settings['include_in_shared_search']
       if parent_tenant.present? && shared_search_check == 'true'
-        Ubiquity::SharedIndexSolrServiceWrapper.new(self.to_solr, 'add', parent_tenant, get_file_sets, shared_search_check).update
+        Ubiquity::SharedIndexSolrServiceWrapper.new(self.to_solr, 'add', parent_tenant, shared_search_check).update
         #if you switch the tenant back to the one that owns the work, you will get a blacklight error rendering show
         AccountElevator.switch!(self.account_cname)
       end
@@ -46,11 +48,12 @@ module Ubiquity
     end
 
     def get_file_sets
-      if self.class != FileSet && self.try(:file_sets).present?
+      shared_search_check =  get_account_tenant && get_account_tenant.settings['include_in_shared_search']
+
+      if self.class != FileSet && self.try(:file_sets).present? && parent_tenant.present? && shared_search_check == 'true'
+        file_sets_solr =  self.file_sets.map(&:to_solr)
+        Ubiquity::SharedIndexSolrServiceWrapper.new(file_sets_solr, 'add', parent_tenant, shared_search_check).update
         AccountElevator.switch!(self.account_cname)
-        self.file_sets.map do |file_set|
-          file_set.to_solr if file_set.present?
-        end.compact
       end
     end
 

--- a/app/services/ubiquity/shared_index_solr_service_wrapper.rb
+++ b/app/services/ubiquity/shared_index_solr_service_wrapper.rb
@@ -2,7 +2,7 @@ module Ubiquity
   class SharedIndexSolrServiceWrapper
     attr_accessor :solr_document, :action_type, :tenant_cname, :file_sets, :add_to_in_shared_search
 
-    def initialize(solr_document, action_type, tenant_cname, file_sets = nil, add_to_in_shared_search = nil)
+    def initialize(solr_document, action_type, tenant_cname, add_to_in_shared_search = nil, file_sets = nil)
       @solr_document = solr_document
       @action_type = action_type
       @file_sets = file_sets


### PR DESCRIPTION
https://trello.com/c/fTpzGNZV/450-v15929-update-filters-to-include-facet-by-file-availability-switched-off