### PR TITLE
return empty hashif object is nil in rescue when block  to_solr fails in file_set indexer when running file_availability rake task

### DIFF
--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -9,6 +9,6 @@ class FileSetIndexer < Hyrax::FileSetIndexer
   rescue Ldp::HttpError => exception
      puts "exception is: #{exception.inspect}"
      puts "calling to_solr on fileset failed #{object.inspect}"
-     object || { }
+     { }
   end
 end

--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -9,6 +9,6 @@ class FileSetIndexer < Hyrax::FileSetIndexer
   rescue Ldp::HttpError => exception
      puts "exception is: #{exception.inspect}"
      puts "calling to_solr on fileset failed #{object.inspect}"
-     object 
+     object || { }
   end
 end


### PR DESCRIPTION
https://trello.com/c/fTpzGNZV/450-v15929-update-filters-to-include-facet-by-file-availability-switched-off