### PR TITLE
Use ActiveFedora::IndexingService to generate values accepted by solr if calling to_solr on the file_set fails when running the rake task for file_set availability 

### DIFF
--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -9,6 +9,12 @@ class FileSetIndexer < Hyrax::FileSetIndexer
   rescue Ldp::HttpError => exception
      puts "exception is: #{exception.inspect}"
      puts "calling to_solr on fileset failed #{object.inspect}"
-     { }
+
+     #manually call generate_solr_document on the indexing_service. It returns
+     # the same values as calling to_solr on a file_set object
+     get_solr_attributes = ActiveFedora::IndexingService.new(object).generate_solr_document
+     puts "get_solr_attributes #{get_solr_attributes.inspect}"
+     get_solr_attributes
   end
+
 end


### PR DESCRIPTION
Use ActiveFedora::IndexingService to generate values accepted by solr if calling to_solr on the file_set fails when running the rake task for file_set availability 