### PR TITLE
add ability to sort search results by date_published using year only

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -423,11 +423,14 @@ class CatalogController < ApplicationController
     # except in the relevancy case).
     # label is key, solr field is value
     config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
+    config.add_sort_field "date_published_si desc, #{uploaded_field} desc", label: "date published \u25BC"
+    config.add_sort_field "date_published_si asc, #{uploaded_field} desc", label: "date published \u25B2"
+
     #
     #Commented out by UbiquityPress to remove them from the sort options in search result page
     #
+    # config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
+    # config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
     #config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
     #config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
 

--- a/app/helpers/ubiquity/date_change_helper.rb
+++ b/app/helpers/ubiquity/date_change_helper.rb
@@ -2,18 +2,7 @@ module  Ubiquity
   module DateChangeHelper
 
     def parse_date(date, date_part)
-      return nil if date.blank?
-      split_date = date.split('-') if date.respond_to?(:split)
-      if date_part == 'year'
-        return date.strftime("%Y") if date.respond_to?(:strftime)
-        split_date[0]
-      elsif date_part == 'month'
-        return date.strftime("%m") if date.respond_to?(:strftime)
-        split_date[1] if split_date.length > 1
-      elsif date_part == 'day'
-        return date.strftime("%d") if date.respond_to?(:strftime)
-        split_date[2] if split_date.length == 3
-      end
+       Ubiquity::ParseDate.return_date_part(date, date_part)
     end
 
   end

--- a/app/indexers/shared_indexer.rb
+++ b/app/indexers/shared_indexer.rb
@@ -5,6 +5,7 @@ class SharedIndexer < Hyrax::WorkIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc[Solrizer.solr_name('contributor_list', :stored_searchable)] = Ubiquity::ParseJson.new(object.contributor.first).fetch_value_based_on_key('contributor')
+      solr_doc['date_published_si'] = Ubiquity::ParseDate.return_date_part(object.date_published, 'year')
     end
   end
 end

--- a/app/services/ubiquity/parse_date.rb
+++ b/app/services/ubiquity/parse_date.rb
@@ -15,11 +15,26 @@ module Ubiquity
       return_values
     end
 
+    def self.return_date_part(date, date_part)
+      return nil if date.blank?
+      split_date = date.split('-') if date.respond_to?(:split)
+      if date_part == 'year'
+        return date.strftime("%Y") if date.respond_to?(:strftime)
+        split_date[0]
+      elsif date_part == 'month'
+        return date.strftime("%m") if date.respond_to?(:strftime)
+        split_date[1] if split_date.length > 1
+      elsif date_part == 'day'
+        return date.strftime("%d") if date.respond_to?(:strftime)
+        split_date[2] if split_date.length == 3
+      end
+    end
+
     private
 
     def transform_date_group(date)
       date_parts =  date.split('-')
-      
+
       year = "#{date_field}_year"
       month = "#{date_field}_month"
       day = "#{date_field}_day"

--- a/lib/tasks/ubiquity_resave_records.rake
+++ b/lib/tasks/ubiquity_resave_records.rake
@@ -1,17 +1,35 @@
 #run from  the terminal with and the rake task takes one argument
 # Note the tenant name is supplied when running the rake task, for example
 # if the tenant name is 'sandbox.repo-test.ubiquity.press', you will pass it as shown below
-# rake ubiquity_index_file_availability_facet:update['sandbox.repo-test.ubiquity.press']
+# rake ubiquity_resave_records:all['sandbox.repo-test.ubiquity.press']
 #for updatinga specific model note the surrounding string after the rake command
-# rake "ubiquity_index_file_availability_facet:update_specific_model[sandbox.repo-test.ubiquity.press,  generic_work]"
+# rake "ubiquity_resave_records:update_specific_model[sandbox.repo-test.ubiquity.press,  generic_work]"
+#
+# rake ubiquity_resave_records:all_exempt_collections['sandbox.repo-test.ubiquity.press']
 
-namespace :ubiquity_index_file_availability_facet do
-  desc "Run this task to popolate the file_availability field for existing works"
 
-  task :update, [:name] => :environment do |task, tenant|
+namespace :ubiquity_resave_records do
+  desc "Update data by resaving records for existing works"
+
+  task :all, [:name] => :environment do |task, tenant|
 
     #These are the names of the existing work type in UbiquityPress's Hyku
     model_class = [Collection, Article, Book, BookContribution, ConferenceItem, Dataset, ExhibitionItem, Image, Report, ThesisOrDissertation, TimeBasedMedia, GenericWork]
+    AccountElevator.switch!("#{tenant[:name]}")
+    model_class.each do |model|
+      #We fetching an instance of the models and then getting the value in the creator field
+      model.find_each do |model_instance|
+         #by calling save we trigger the before_save callback in app/models/ubiquity/concerns/multiple_modules.rb
+          model_instance.save
+          sleep 2
+      end
+    end
+  end
+
+  task :all_exempt_collections, [:name] => :environment do |task, tenant|
+
+    #These are the names of the existing work type in UbiquityPress's Hyku
+    model_class = [Article, Book, BookContribution, ConferenceItem, Dataset, ExhibitionItem, Image, Report, ThesisOrDissertation, TimeBasedMedia, GenericWork]
     AccountElevator.switch!("#{tenant[:name]}")
     model_class.each do |model|
       #We fetching an instance of the models and then getting the value in the creator field


### PR DESCRIPTION
https://trello.com/c/EkYxRi1X/137-5-sort-search-results-by-year-published-only

###### Post deployment run to populate date_published_si used for sorting
rake ubiquity_resave_records:all_exempt_collections['library.localhost']

