### PR TITLE
restore ability to for partial update of works with only selected keys via the json-importer

### DIFF
--- a/app/services/ubiquity/json_importer.rb
+++ b/app/services/ubiquity/json_importer.rb
@@ -1,3 +1,8 @@
+#reverted ability to update via the importer
+#https://github.com/ubiquitypress/hyku/pull/432
+#this commit contains the code on this file which added the ability to update code via the importer
+#https://github.com/ubiquitypress/hyku/pull/407
+#https://trello.com/c/ny0pVK4C/584-v15924-allow-json-importer-to-update-records-based-on-keys-in-imported-csv-revert-before-release-to-live
 
 #To run from rails console
 #create a json or use the constants set as a examples in queue_import.#!/usr/bin/env ruby -wKU
@@ -7,15 +12,22 @@
 module Ubiquity
   class JsonImporter
     attr_reader :ubiquity_model_class
+    #hash_for_import method is used to
+    #determine what hash keys to use. For existing records using the attributes key and for new records use the keys from the imported json
+    #
+    #attributes_hash
+    #this is where we temporarily store the parsed imported data before save
+
+    attr_accessor :attributes_hash, :work, :hash_for_import
 
     def initialize(data)
+      @attributes_hash = {}
       @data = data
       $stdout.puts "Log Json data loaded #{@data}"
 
       @data_id  = data.delete('id') || data.delete(:id)
       @tenant = data['tenant'] || data[:tenant]
       @domain = data['domain'] || data[:domain]
-
       @tenant_domain = @tenant + '.' + @domain
       @data_hash = HashWithIndifferentAccess.new(data)
       @file = @data_hash[:file]
@@ -29,28 +41,56 @@ module Ubiquity
 
       @user = User.where(email: @work_instance.depositor).first ||  User.find_or_create_by(email: email) { |user|  user.password = 'abcdefgh'; user.password_confirmation = 'abcdefgh'}
 
-      @work_instance.depositor = @user.email unless @work_instance.depositor
+      @attributes_hash['depositor'] = @user.email unless @work_instance.depositor
       $stdout.puts "Started parsing the json data"
 
-      @work_instance.attributes.each_with_index do |(key, val), index|
+      hash_from_work_and_submitted_data.each_with_index do |(key, val), index|
         #index needed to to ensure set_default_work_visibility is called once inside populate_array_field
         populate_array_field(key, val, index)
         populate_json_field(key, val)
         populate_single_fields(key, val)
       end
-      @work_instance.account_cname = @tenant_domain
-      @work_instance.date_modified = Hyrax::TimeService.time_in_utc
-      @work_instance.date_uploaded = Hyrax::TimeService.time_in_utc unless @work_instance.date_uploaded.present?
-      puts "#{@work_instance.inspect}"
-      @work_instance.save!
+      @attributes_hash['account_cname'] = @tenant_domain
+      @attributes_hash['date_modified'] = Hyrax::TimeService.time_in_utc
+      @attributes_hash['date_uploaded'] = Hyrax::TimeService.time_in_utc unless @work_instance.date_uploaded.present?
+
+      #save the work
+      create_or_update_work
       add_state_to_work
       $stdout.puts "work was successfully created"
 
       attach_files
       @work_instance
+      @work = @work_instance
+      self
     end
 
     private
+
+    #determine what hash keys to use. For existing records using the attributes key and for new records use the keys from the imported json
+    #
+    def hash_from_work_and_submitted_data
+      work_keys = @work_instance.attributes.keys
+      work_hash_with_indifference_access = @work_instance.attributes.with_indifferent_access
+      data_with_indifferent_access = @data.with_indifferent_access
+      if @work_instance.new_record?
+         @hash_for_import = data_with_indifferent_access.slice(*work_keys)
+      else
+        @hash_for_import = work_hash_with_indifference_access.slice(*@data.keys)
+      end
+
+    end
+
+    def create_or_update_work
+      if @work_instance.new_record?
+        @work_instance.attributes = attributes_hash
+        puts "new-work #{@work_instance.inspect}"
+        @work_instance.save!
+      else
+        puts "updating-work with #{attributes_hash.inspect}"
+        @work_instance.update(attributes_hash)
+      end
+    end
 
     def model_instance
       AccountElevator.switch!("#{@tenant_domain}")
@@ -82,70 +122,65 @@ module Ubiquity
     def set_default_work_visibility(key)
       if (['open', 'restricted'].include? @data_hash[:visibility])
         puts "setting visibility from hash - #{@data_hash[:visibility]}"
-        @work_instance.assign_attributes(visibility:  @data_hash[:visibility])
-
+        @attributes_hash['visibility'] = @data_hash[:visibility]
       else
         puts "setting visibility to private the json importer's default  #{@data_hash[:visibility]}"
-        #@work_instance.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE unless @work_instance.visibility.present?
         if (key == "file_only_import" && key != 'true')
-         @work_instance.assign_attributes(visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) unless @work_instance.visibility.present?
+         @attributes_hash['visibility'] = (Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) unless @work_instance.visibility.present?
         end
       end
     end
 
     def  populate_array_field(key, val, index)
       set_default_work_visibility(key) if index == 0
-      if (@data_hash[key].present? && (@work_instance.send(key).respond_to? :length) && (not val.class == String) && (not ['creator', 'editor', 'contributor', 'alternate_identifier', 'related_identifier'].include? key))
-        #@work_instance.assign_attributes(key => @data_hash[key].split('||')) if (key == "file_only_import" && key != 'true')
+
+      if ( (not ['creator', 'editor', 'contributor', 'alternate_identifier', 'related_identifier'].include? key) && (@work_instance.send(key).class == ActiveTriples::Relation) )
         create_or_skip_work_metadata('array', key)
       end
       @work_instance
     end
 
     def populate_json_field(key, val)
-      if (@data_hash[key].present? && (@work_instance.send(key).respond_to? :length) && (not val.class == String) && (['creator', 'editor', 'contributor', 'alternate_identifier', 'related_identifier'].include? key))
-        #@work_instance.assign_attributes(key => [@data_hash[key].to_json]) if (key == "file_only_import" && key != 'true')
+      if ( (['creator', 'editor', 'contributor', 'alternate_identifier', 'related_identifier'].include? key)  && (not val.class == String) )
         create_or_skip_work_metadata('json', key)
       end
       @work_instance
     end
 
     def populate_single_fields(key, val)
-      if (@data_hash[key].present? && (@data_hash[key].class == String) && (not val.class == ActiveTriples::Relation) && (not ['creator', 'editor', 'contributor', 'alternate_identifier', 'related_identifier'].include? key))
-        #@work_instance.assign_attributes(key =>  @data_hash[key]) if (key == "file_only_import" && key != 'true')
+      if ( (@work_instance.send(key).class != ActiveTriples::Relation) && (val.class == String) && (not ['creator', 'editor', 'contributor', 'alternate_identifier', 'related_identifier'].include? key))
         create_or_skip_work_metadata('string', key)
       end
       @work_instance
     end
 
     def create_or_skip_work_metadata(type, key)
-      if (@data_hash["file_only_import"].present? == false) #&& @data_has["file_only_import"] == 'true')
-      #elsif @data_has["file_only_import"].present? == false
-        puts "populating metadata"
-        populate_work_values(type, key)
-      end
+      puts "populating metadata"
+      populate_work_values(type, key)
       @work_instance
     end
 
     def populate_work_values(type, key)
       if type == 'string'
-        #@work_instance.assign_attributes(key =>  @data_hash[key])
         puts "populating metadata string fields"
-        @work_instance.assign_attributes(key =>  @data_hash[key])
+        @attributes_hash[key] = @data_hash[key]
       elsif type == 'array'
         puts "populating metadata array fields"
-        @work_instance.assign_attributes(key => @data_hash[key].split('||'))
+        value = (@data_hash[key].present? ? @data_hash[key].split('||') : [])
+        @attributes_hash[key] = value
       elsif type == 'json'
         puts "populating metadata json fields"
-        @work_instance.assign_attributes(key => [@data_hash[key].to_json])
+        @attributes_hash[key] = [@data_hash[key].to_json]
       end
       @work_instance
     end
 
     def create_file_from_array
       @hyrax_uploaded_file = []
-      file_array = @file.split('||')
-      create_multiple_files(file_array)
+      if @file.present?
+        file_array = @file.split('||')
+        create_multiple_files(file_array)
+      end
     end
 
     def create_multiple_files(file_array)
@@ -165,7 +200,6 @@ module Ubiquity
     end
 
     def create_file_directly(file)
-      #file = Tempfile.new(file)
       file = File.new(File.expand_path(file))
       file_name = File.basename(file.path)
       io = ActionDispatch::Http::UploadedFile.new(tempfile: file, filename: file_name)


### PR DESCRIPTION
https://trello.com/c/ny0pVK4C/584-v15924-allow-json-importer-to-update-records-based-on-keys-in-imported-csv-was-reverted-before-release-1600-needs-un-reverting

### While testing locally using  the steps below, ensure:
1.  You replace the path to any file in the hash with a local file path or give it no file.
2. Use you local tenant name and domain

### TESTING IT LOCALLY
1. Use either Nms, Sandbox, Sample or Stuff which are 4  constants holding similar json to what we expect from the Python Importer. These constants are defined here:
https://github.com/ubiquitypress/hyku/blob/test/app/services/ubiquity/queue_import.rb#L100-L240

Start Rails and Sidekiq . Then in Rails console do the following:

    k = Nms

    QueueImport.upload(k)

That will create a job via the importer

Then to update the just the title of the work created via NMS use this new hash for a partial update

    ku = {:id => "d76279db-c5cb-46d1-a964-a49b615ff131", :title => "test no visibility key", :domain => "localhost", :tenant=> "library"}

    QueueImport.upload(ku)

Finally lets set the value of keyword to nil via the importer

    x = {:id => "d76279db-c5cb-46d1-a964-a49b615ff131", :keyword => " " , :domain => "localhost", :tenant=> "library"}

    QueueImport.upload(x)


