### PR TITLE
Fixed the issue in chopping the url

### DIFF
--- a/app/models/concerns/ubiquity/track_doi_options.rb
+++ b/app/models/concerns/ubiquity/track_doi_options.rb
@@ -21,7 +21,6 @@ module Ubiquity
       def clean_doi
         refined_url = remove_unwanted_characters_from_doi
         doi_path = Addressable::URI.parse(refined_url).path
-        doi_path = doi_path.chop if [';', '.', '&'].include? doi[-1]
         self.doi = doi_path
       end
 


### PR DESCRIPTION
Fixes: https://trello.com/c/HQZcIqPK/618-1614bad-doi-format-makes-hyku-crash-changes-needed-to-make-hyku-correct-the-format

Removed chopping of the last character of url for special characters
