### PR TITLE
Added parsing for url in datacite

### DIFF
--- a/app/services/ubiquity/datacite_client.rb
+++ b/app/services/ubiquity/datacite_client.rb
@@ -56,7 +56,7 @@ module Ubiquity
       def parse_url(url)
         url = url.strip
         handle_client do
-          uri = URI.parse(url)
+          uri = Addressable::URI.convert_path(url)
           if (uri.scheme.present? &&  uri.host.present?)
             path_name = uri.path
             use_path(path_name)


### PR DESCRIPTION
Fixes: https://trello.com/c/QI9QAOHe/608-support-old-style-crossref-dois-in-metadata-lookup-deposit-form-auto-fill
