### PR TITLE
changing a file's visibility from private to public should update fil…

### DIFF
--- a/app/models/concerns/ubiquity/file_availability_faceting.rb
+++ b/app/models/concerns/ubiquity/file_availability_faceting.rb
@@ -22,24 +22,31 @@ module Ubiquity
 
     def set_file_availability_for_faceting
       if ('open'.in? get_work_filesets_visibility)  && self.official_link.present? && (doi_option_value_check? == true)
+
         self.file_availability = ['File available from this repository']
 
-      elsif ('open'.in? get_work_filesets_visibility) && !self.official_link.present? && (doi_option_value_check? == false)
+      elsif ('open'.in? get_work_filesets_visibility) && self.official_link.blank?  && (doi_option_value_check? == false)
+
         self.file_availability = ['File available from this repository']
 
       elsif ('open'.in? get_work_filesets_visibility) && self.official_link.present? && (doi_option_value_check? == false)
+
         multiple_values
 
       elsif (get_work_filesets_visibility.any? {|status| status.in? ['authenticated', 'restricted'] } || get_work_filesets_visibility.blank? ) && self.official_link.present? && (doi_option_value_check? == false)
+
         self.file_availability =  ["External link (access may be restricted)"]
 
       elsif (get_work_filesets_visibility.any? {|status| status.in? ['authenticated', 'restricted'] } || get_work_filesets_visibility.blank?) && !self.official_link.present? && (doi_option_value_check? == true)
+
         self.file_availability = ['File not available']
 
       elsif (get_work_filesets_visibility.any? {|status| status.in? ['authenticated', 'restricted'] } || get_work_filesets_visibility.blank?) && self.official_link.present? && (doi_option_value_check? == true)
+
         self.file_availability = ['File not available']
 
       elsif (get_work_filesets_visibility.any? {|status| status.in? ['authenticated', 'restricted'] } || get_work_filesets_visibility.blank?) && !self.official_link.present? && (doi_option_value_check? == false)
+        
         self.file_availability = ['File not available']
       end
     end

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -8,7 +8,8 @@ class FileSet < ActiveFedora::Base
 
   before_destroy :remove_rendering_relationship
   before_save :set_account_cname
-  before_update :fetch_file_sets_and_create_work_expiry_service, :parent_save_to_update_file_visibility_facet
+  before_update :fetch_file_sets_and_create_work_expiry_service
+  after_save :parent_save_to_update_file_visibility_facet, on: [:update]
 
   # Hyku has its own FileSetIndexer: app/indexers/file_set_indexer.rb
   # It overrides Hyrax to inject IIIF behavior.


### PR DESCRIPTION
https://trello.com/c/fTpzGNZV/450-1614v16010v15929-update-filters-to-include-facet-by-file-availability

### To test it
1. Add multiples files  to a work and make all the files private
2. Check the search page and see which category they enter in file_availability facet
3. Edit the work and change one of the files from  a "private" file into "public
4. Repeat step 2


###### Original problem fixed by this pull request

there is no problem when you have multiples files that change from "public" to "private" (they immediately show in "File not available" BUT the problem, or long delay, arises when you change a "private" file into "public"