### PR TITLE
Download button large files

### DIFF
--- a/app/views/shared/ubiquity/file_sets/_restricted_media.html.erb
+++ b/app/views/shared/ubiquity/file_sets/_restricted_media.html.erb
@@ -1,7 +1,8 @@
 <!--  Hyku::ManifestEnabledWorkShowPresenter -->
 <!-- This whole file was add ubiquitypress to selectively display universalviewer-->
-<% file_size = presenter.representative_presenter.solr_document["file_size_lts"] %><br>
-<%= hidden_field_tag 'ubiquity-file-size', file_size %>
+<% file_set_presenter = presenter.representative_presenter %><br>
+<% solr_document = presenter.representative_presenter.solr_document %><br>
+<% file_size = solr_document["file_size_lts"] %>
 
 <% if presenter.try(:representative_presenter).try(:image?) %>
   <% file_set_presenter = presenter.representative_presenter %>
@@ -16,15 +17,12 @@
     <div class="viewer-wrapper"><div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, presenter] %>"></div></div>
   <% end %>
 <% else %>
+  <% if file_size < 10.gigabytes %>
     <%= media_display presenter.try(:representative_presenter) %>
-<% end %>
-
-<script>
-  $(document).on("turbolinks:load", function(event){
-     var tenGigabyte = 10737418240
-     var fileSize = $("#ubiquity-file-size").val();
-     if (fileSize > tenGigabyte ){
-       return $('#file_download').hide();
-     }
-  });
-</script>
+  <%else%>
+    <div class="no-preview">
+      No preview available<br>
+      <%= load_file_from_file_set(file_set_presenter, file_size)%>
+    </div>
+  <%end%>
+<%end%>

--- a/app/views/shared/ubiquity/file_sets/_restricted_media.html.erb
+++ b/app/views/shared/ubiquity/file_sets/_restricted_media.html.erb
@@ -1,5 +1,8 @@
 <!--  Hyku::ManifestEnabledWorkShowPresenter -->
 <!-- This whole file was add ubiquitypress to selectively display universalviewer-->
+<% file_size = presenter.representative_presenter.solr_document["file_size_lts"] %><br>
+<%= hidden_field_tag 'ubiquity-file-size', file_size %>
+
 <% if presenter.try(:representative_presenter).try(:image?) %>
   <% file_set_presenter = presenter.representative_presenter %>
   <!-- dont' displays universal viewer for files with archived format eg zip -->
@@ -15,3 +18,13 @@
 <% else %>
     <%= media_display presenter.try(:representative_presenter) %>
 <% end %>
+
+<script>
+  $(document).on("turbolinks:load", function(event){
+     var tenGigabyte = 10737418240
+     var fileSize = $("#ubiquity-file-size").val();
+     if (fileSize > tenGigabyte ){
+       return $('#file_download').hide();
+     }
+  });
+</script>


### PR DESCRIPTION
Resolves: https://trello.com/c/ZmRtstLE/421-2-download-button-at-top-of-show-work-page-where-there-is-a-thumbnail-should-be-changed-to-contact-for-file