### PR TITLE
Removing the 3000 port in the tenant url address

### DIFF
--- a/app/services/ubiquity/fetch_tenant_url.rb
+++ b/app/services/ubiquity/fetch_tenant_url.rb
@@ -8,12 +8,12 @@ module Ubiquity
     end
 
     def process_url
-      retunr nil if @account_cname.nil?
+      return nil if @account_cname.nil?
       work_type = @work_type.downcase.pluralize
       if @account_cname.split('.').include? 'localhost'
         "http://#{@account_cname}:3000/concern/#{work_type}/#{@id}"
       else
-        "https://#{@account_cname}:3000/concern/#{work_type}/#{@id}"
+        "https://#{@account_cname}/concern/#{work_type}/#{@id}"
       end
     end
   end


### PR DESCRIPTION
Fixes : https://trello.com/c/gemPv5Tz/165-16117-16116-oai-pmh-harvesting-is-in-place

Fixed OAI-PMH tenant url for the live tenants
