### PR TITLE
revert changes that caused wrong ordering of json in  csv column headers

### DIFF
--- a/app/services/ubiquity/csv_generator.rb
+++ b/app/services/ubiquity/csv_generator.rb
@@ -56,8 +56,7 @@ module Ubiquity
     def merged_headers(csv_data_object)
       sorted_header = []
       all_keys = csv_data_object.flat_map(&:keys).uniq
-      #resort using ordering by suffix eg creator_isni_1 comes before creator_isni_2
-      all_keys = all_keys.sort_by{ |name| [name[/\d+/].to_i, name] if ['creator, contributor', 'editor'].include?(name)}
+      all_keys = all_keys.sort_by{ |name| [name[/\d+/].to_i] }
       Ubiquity::CsvDataRemap::CSV_HEARDERS_ORDER.each {|k| all_keys.select {|e| sorted_header << e if e.start_with? k} }
       sorted_header.uniq
     end


### PR DESCRIPTION
https://trello.com/c/8QuJT627/411-161171615v15924-make-improvements-to-export-a-csv-file-of-the-repository-metadata