### PR TITLE
refactoring mailer code

### DIFF
--- a/app/mailers/work_report_mailer.rb
+++ b/app/mailers/work_report_mailer.rb
@@ -6,26 +6,13 @@ class WorkReportMailer < ApplicationMailer
     @period = fetch_subject_based_on(email_type)
     @email_type = email_type
     date_period = fetch_date_by(email_type)
-    @data = fetch_data(date_period)
-    @summary_data = fetch_data('[* TO *]')
+    @data = Ubiquity::FetchMailerReportData.fetch_data(date_period)
+    @summary_data = Ubiquity::FetchMailerReportData.fetch_data('[* TO *]')
     @resource_type_hash = load_resource_type_yaml
     mail(to: email, subject: "Activity report for #{@cname} for #{@period}")
   end
 
   private
-
-    def fetch_data(date_range)
-      query_data = ActiveFedora::SolrService.query(
-        "system_create_dtsi: #{date_range}",
-        {
-          fl: ['resource_type_tesim, human_readable_type_tesim, file_set_ids_ssim, hasEmbargo_ssim, hasLease_ssim, visibility_ssi, lease_history_ssim, embargo_history_ssim'],
-          fq: ['{!terms f=has_model_ssim}Article,Book,BookContribution,ConferenceItem,Dataset,ExhibitionItem,Image,Report,ThesisOrDissertation,TimeBasedMedia,GenericWork'],
-          rows: 100_000_000
-        }
-      )
-      sorted_array = query_data.sort_by{ |e| [e["human_readable_type_tesim"]] }.group_by { |e| e["human_readable_type_tesim"] }.to_h.values.flatten
-      Ubiquity::FetchMailerReportData.new(sorted_array).generate_report
-    end
 
     def load_resource_type_yaml
       resource_type = YAML.load_file('config/authorities/resource_types.yml')

--- a/app/services/ubiquity/fetch_mailer_report_data.rb
+++ b/app/services/ubiquity/fetch_mailer_report_data.rb
@@ -5,6 +5,19 @@ module Ubiquity
       @sorted_array = sorted_array
     end
 
+    def self.fetch_data(date_range)
+      query_data = ActiveFedora::SolrService.query(
+        "system_create_dtsi: #{date_range}",
+        {
+          fl: ['resource_type_tesim, human_readable_type_tesim, file_set_ids_ssim, hasEmbargo_ssim, hasLease_ssim, visibility_ssi, lease_history_ssim, embargo_history_ssim'],
+          fq: ['{!terms f=has_model_ssim}Article,Book,BookContribution,ConferenceItem,Dataset,ExhibitionItem,Image,Report,ThesisOrDissertation,TimeBasedMedia,GenericWork'],
+          rows: 100_000_000
+        }
+      )
+      sorted_array = query_data.sort_by{ |e| [e["human_readable_type_tesim"]] }.group_by { |e| e["human_readable_type_tesim"] }.to_h.values.flatten
+      new(sorted_array).generate_report
+    end
+
     def generate_report
       final_hash = {}
       @sorted_array.group_by { |e| e['resource_type_tesim'] }.each do |key, value|
@@ -39,5 +52,6 @@ module Ubiquity
       end
       final_hash
     end
+
   end
 end


### PR DESCRIPTION
Refactored the WorkReportMailer class so instance variables `@data  and  @summary_data `  :
can now use the `Ubiquity::FetchMailerReportData` class and fetch the data calling the class method `self.method fetch_data` like so:

```
@data = Ubiquity::FetchMailerReportData.fetch_data(date_period)
@summary_data = Ubiquity::FetchMailerReportData.fetch_data('[* TO *]')
```