### PR TITLE
shared-search now uses db settings to determine tenants to exempt from shared-search

### DIFF
--- a/app/controllers/ubiquity/account_settings_controller.rb
+++ b/app/controllers/ubiquity/account_settings_controller.rb
@@ -23,7 +23,8 @@ class Ubiquity::AccountSettingsController < AdminController
   end
 
   def account_params
-    params.require(:account).permit(:settings => [:contact_email, weekly_email_list: [], monthly_email_list: [], yearly_email_list: []])
+    params.require(:account).permit(:settings => [:contact_email, :index_record_to_shared_search, weekly_email_list: [],
+                                   monthly_email_list: [], yearly_email_list: []])
   end
 
 end

--- a/app/models/concerns/ubiquity/account_self_join_association.rb
+++ b/app/models/concerns/ubiquity/account_self_join_association.rb
@@ -8,8 +8,26 @@ module Ubiquity
       belongs_to :parent, class_name: "Account", inverse_of: :parent, foreign_key: "parent_id", optional: true
 
       store_accessor :data, :is_parent
-      store_accessor :settings, :contact_email, :weekly_email_list, :monthly_email_list, :yearly_email_list
+      store_accessor :settings, :contact_email, :weekly_email_list, :monthly_email_list, :yearly_email_list,
+                     :index_record_to_shared_search
+
+      after_initialize :set_index_to_shared_search_for_live_sites, :set_index_to_shared_search_for_demo_sites
+
     end
-    
+
+    private
+
+    def set_index_to_shared_search_for_live_sites
+      if cname.present? && !cname.include?('demo')
+        self.settings['index_record_to_shared_search'] = 'true' if settings['index_record_to_shared_search'].blank?
+      end
+    end
+
+    def set_index_to_shared_search_for_demo_sites
+      if cname.present? && 'demo'.in?(self.cname)
+        self.settings['index_record_to_shared_search'] = 'false' if settings['index_record_to_shared_search'].blank?
+      end
+    end
+
   end
 end

--- a/app/views/ubiquity/account_settings/edit.html.erb
+++ b/app/views/ubiquity/account_settings/edit.html.erb
@@ -30,6 +30,10 @@
               <%= ff.text_field :monthly_email_list, :value => current_account.settings["monthly_email_list"], name: "#{f.object_name}[settings][monthly_email_list][]", class: 'form-control' %><br>
               <%= ff.label :yearly_email_list %><br>
               <%= ff.text_field :yearly_email_list, :value => current_account.settings["yearly_email_list"], name: "#{f.object_name}[settings][yearly_email_list][]", class: 'form-control' %><br>
+              <b><%= ff.label 'Index record to shared search' %></b><br>
+             <p>True: newly added/edited works will appear in Shared Search</p>
+             <p>False: newly added works will NOT appear in Shared Search</p>
+             <%= ff.select :index_record_to_shared_search, options_for_select(['true', 'false'], @account.settings['index_record_to_shared_search']), {class: 'form-control', prompt: "Select one"} %>
             <% end %>
           </div>
 

--- a/app/views/ubiquity/account_settings/index.html.erb
+++ b/app/views/ubiquity/account_settings/index.html.erb
@@ -12,7 +12,13 @@
     <tbody>
       <tr>
         <td><b>Contact email:</b> <%= @account && @account.settings && @account.settings["contact_email"] %></td> <br>
-        <td><%= link_to "Edit email & mailing lists", edit_admin_account_setting_path(@account), class: "btn btn-xs btn-default" %></td>
+        <td><%# link_to "Edit email & mailing lists", edit_admin_account_setting_path(@account), class: "btn btn-xs btn-default" %></td>
       </tr>
+      <tr>
+       <td><b>Index records to shared search:</b> <%= @account && @account.settings && @account.settings["index_record_to_shared_search"]  %> </td> <br>
+     </tr>
+     <tr>
+     <td><%= link_to "Edit your account settings", edit_admin_account_setting_path(@account), class: "btn btn-xs btn-default" %></td>
+   </tr>
     </tbody>
 </table>


### PR DESCRIPTION
https://trello.com/c/EQuv9SXH/605-v1602-enable-or-disable-shared-search-from-the-ui-account-settings-set-to-false-to-exempt-a-tenants-record-from-being-indexed-to