### PR TITLE
refactor emailer preview to use ENV variables

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ fi
 bundle exec rails zookeeper:upload
 
 # Start sidekiq
-bundle exec sidekiq -d -q ubiquity_json_importer,2 -q default,2 -q expiry_service,1 -L kiq.log
+bundle exec sidekiq -d -q ubiquity_json_importer,2 -q default,2 -q expiry_service,1, -q mailers,1 -L kiq.log
 
 # Start server
 rm -f tmp/pids/server.pid && bundle exec rails db:migrate && bundle exec rails server -p 3000 -b '0.0.0.0'

--- a/spec/mailers/previews/work_report_mailer_preview.rb
+++ b/spec/mailers/previews/work_report_mailer_preview.rb
@@ -2,7 +2,11 @@
 class WorkReportMailerPreview < ActionMailer::Preview
 
   def send_report
-    WorkReportMailer.send_report('ashikajith@gmail.com', 'ashik.localhost', 'weekly_email_list').deliver_now
+    email = ENV['SMTP_USERNAME']
+    tenant = ENV['DEVELOPER_PREVIEW_EMAIL_HOST_NAME']
+    if email.present? && tenant.present?
+      WorkReportMailer.send_report(email, tenant, 'weekly_email_list')
+    end
   end
 
 end


### PR DESCRIPTION
Refactored mailer review to use ENV variables as follows: 
```
email = ENV['SMTP_USERNAME']
tenant = ENV['DEVELOPER_PREVIEW_EMAIL_HOST_NAME']
```