### PR TITLE
refactor enable doi method to check for the tenant name presence in t…

### DIFF
--- a/app/models/concerns/ubiquity/work_doi_lifecycle.rb
+++ b/app/models/concerns/ubiquity/work_doi_lifecycle.rb
@@ -16,7 +16,6 @@ module Ubiquity
       if doi_enabled? && self.visibility == 'open' && self.draft_doi && (self.doi_options == 'Mint DOI:Registered' || self.doi_options == 'Mint DOI:Findable')
         puts "Post to indexer #{self.id}"
         Ubiquity::IndexerClient.new(self.id, self.draft_doi, self.account_cname).post
-
       end
     end
 
@@ -26,7 +25,7 @@ module Ubiquity
         tenant_json = ENV["TENANTS_SETTINGS"]
         tenant_hash = JSON.parse(tenant_json) if is_valid_json?(tenant_json)
         feature_hash = JSON.parse(ENV['FEATURE_ENABLED']) if is_valid_json?(ENV['FEATURE_ENABLED'])
-        if tenant_hash.present? && feature_hash.present? && tenant_hash[tenant_name]['datacite_prefix'].present?
+        if tenant_hash[tenant_name].present? && feature_hash.present? && tenant_hash[tenant_name]['datacite_prefix'].present?
           (feature_hash['doi_option'] == 'true') && (tenant_hash[tenant_name]['ENABLE_DOI'] == "true")
         end
       end


### PR DESCRIPTION
Fixes the nil class error if there are no tenant settings in the tenant hash, by checking for the presence of the tenant_name