### PR TITLE
Fix licence issues with renaming the licence, make the link open onto…

### DIFF
--- a/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
+++ b/app/presenters/hyku/manifest_enabled_work_show_presenter.rb
@@ -92,8 +92,14 @@ module Hyku
       solr_document['date_submitted_tesim']
     end
 
+    def check_file_licence_count
+      work_id = solr_document['id']
+      work = ActiveFedora::Base.find(work_id)
+      work.file_sets.map {|file_set| file_set.license.count}.sum
+    end
+
    #Added because there was no way to acces file_set_presenter from a  collection page or the search page.
-   #represengter_presenter which returns a file_set_presenter is nil in those places too
+   #representative_presenter which returns a file_set_presenter is nil in those places too
     def thumbnail_presenter
       return nil if thumbnail_id.blank?
       @thumbnail_presenter ||=

--- a/app/views/shared/ubiquity/file_sets/_show_details.html.erb
+++ b/app/views/shared/ubiquity/file_sets/_show_details.html.erb
@@ -1,5 +1,6 @@
 <!-- rendered from app/views/hyrax/file_sets/_show_details.html.erb -->
 <!-- Copied from https://github.com/samvera/hyrax/blob/v2.0.2/app/views/hyrax/file_sets/_show_details.html.erb -->
+
 <h2>File Details</h2>
 <dl class="dl-horizontal file-show-term file-show-details">
   <dt>Depositor</dt>
@@ -27,7 +28,7 @@
   <dd>
     <% master_license_hash = fetch_license_hash %>
       <% @presenter.license.each do |license_links| %>
-        <%= link_to master_license_hash[license_links], license_links %><br>
+        <%= link_to master_license_hash[license_links], license_links, target: :_blank %><br>
       <% end %>
   </dd>
 </dl>

--- a/app/views/shared/ubiquity/works/_items.html.erb
+++ b/app/views/shared/ubiquity/works/_items.html.erb
@@ -2,13 +2,17 @@
  https://github.com/samvera/hyrax/blob/v2.0.2/app/views/hyrax/base/_items.html.erb
  and added to shared/ubiquity/works/item
 -->
+<% license_count = @presenter.check_file_licence_count > 0 ? true : false %>
+
 <% if presenter.member_presenters.present? %>
   <table class="table table-striped related-files">
     <thead>
       <tr>
         <th><%= t('.thumbnail') %></th>
         <th><%= t('.title') %></th>
-        <th><%= t('.licence') %></th>
+        <% if license_count %>
+          <th><%= t('.licence') %></th>
+        <% end %>
         <th><%= t('.date_uploaded') %></th>
         <th><%= t('.visibility') %></th>
         <th> File Size </th>

--- a/app/views/shared/ubiquity/works/_member.html.erb
+++ b/app/views/shared/ubiquity/works/_member.html.erb
@@ -10,7 +10,7 @@
   <td class="attribute file_licence">
     <% master_license_hash = fetch_license_hash %>
     <% member.try(:license).each do |license_links| %>
-      <%= link_to master_license_hash[license_links], license_links %><br>
+      <%= link_to master_license_hash[license_links], license_links, target: :_blank %><br>
     <% end %>
   </td>
 

--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -18,10 +18,10 @@ terms:
     term: CC BY-NC-ND 4.0 Attribution NonCommercial-NoDerivs
     active: true
   - id: https://creativecommons.org/publicdomain/mark/1.0/
-    term: CC0 Public Domain Mark 1.0
+    term: CC Public Domain Mark 1.0
     active: true
   - id: http://creativecommons.org/publicdomain/mark/1.0/
-    term: CC0 Public Domain Mark 1.0
+    term: CC Public Domain Mark 1.0
     active: false
   - id: http://creativecommons.org/publicdomain/zero/1.0/
     term: CC0 1.0 Universal Public Domain


### PR DESCRIPTION
Fixes the issue with licences:
1. renaming one of the licences as per specification
2. making the link to  licence open into a new tab
3. a licence header only appears if a work as at least a file attached with a licence