### PR TITLE
add tenant endpoint with site and content block information

### DIFF
--- a/app/controllers/api/v1/tenant_controller.rb
+++ b/app/controllers/api/v1/tenant_controller.rb
@@ -9,15 +9,18 @@ class API::V1::TenantController < ActionController::Base
     else
       @tenants ||= get_all_tenants
     end
-    if stale?(last_modified: @tenants.maximum(:updated_at), public: true)
-      render json: {total: @tenants.count,  items: @tenants}
-    end
+    #if stale?(last_modified: @tenants.maximum(:updated_at), public: true)
+      #render json: {total: @tenants.count,  items: @tenants}
+    #end
   end
 
   def show
-    if stale?(last_modified: @tenant.updated_at, public: true)
-      render json: @tenant
-    end
+    AccountElevator.switch!(@tenant.cname)
+    @site = @tenant.get_site
+    @content_block = @tenant.get_content_block
+    #if stale?(last_modified: @tenant.updated_at, public: true)
+      #render json: @tenant
+    #end
   end
 
   private

--- a/app/models/concerns/ubiquity/account_self_join_association.rb
+++ b/app/models/concerns/ubiquity/account_self_join_association.rb
@@ -15,6 +15,14 @@ module Ubiquity
 
     end
 
+    def get_site
+      Site.instance
+    end
+
+    def get_content_block
+      ContentBlock.all
+    end
+
     private
 
     def set_index_to_shared_search_for_live_sites

--- a/app/views/api/v1/tenant/_tenant.json.jbuilder
+++ b/app/views/api/v1/tenant/_tenant.json.jbuilder
@@ -1,0 +1,15 @@
+
+AccountElevator.switch!(tenant.cname)
+json.id  tenant.id
+json.tenant  tenant.tenant
+json.cname  tenant.cname
+json.solr_endpoint  tenant.solr_endpoint_id
+json.fcrepo_endpoint  tenant.fcrepo_endpoint_id
+json.name  tenant.name
+json.redis_endpoint  tenant.redis_endpoint_id
+json.parent  tenant.parent_id
+json.settings  tenant.settings
+json.data  tenant.data
+site = tenant.get_site
+json.site  tenant.get_site.attributes.merge("banner_images": {"url": url_for("#{tenant.cname}#{site.banner_image}")})
+json.content_block  tenant.get_content_block

--- a/app/views/api/v1/tenant/index.json.jbuilder
+++ b/app/views/api/v1/tenant/index.json.jbuilder
@@ -1,0 +1,2 @@
+
+json.partial! 'tenant', collection: @tenants, as: :tenant

--- a/app/views/api/v1/tenant/show.json.jbuilder
+++ b/app/views/api/v1/tenant/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'tenant', tenant: @tenant


### PR DESCRIPTION
This PR implements the content block and site to be available form the json at the `/api/v1/tenant/` endpoint.
