### PR TITLE
refactor manifest error to assign the host to account_cname

### DIFF
--- a/app/controllers/api/v1/work_controller.rb
+++ b/app/controllers/api/v1/work_controller.rb
@@ -20,9 +20,9 @@ class API::V1::WorkController < ActionController::Base
   end
 
   def manifest
-    work_class = @work['has_model_ssim']
+    work_class = @work['has_model_ssim'].first.pluralize
     controller_in_use = "Hyrax::#{work_class}Controller".camelize.constantize.new
-    request.env["HTTP_HOST"]  = @work['account_cname_tesim']
+    request.env["HTTP_HOST"]  = @work['account_cname_tesim'].first
     controller_in_use.request = request
     controller_in_use.response = response
     record = controller_in_use.manifest


### PR DESCRIPTION
fixes manifest error by assigning     request.env["HTTP_HOST"]= account_cname