### PR TITLE
add cname to work and collection end-point

### DIFF
--- a/app/views/api/v1/collection/_collection.json.jbuilder
+++ b/app/views/api/v1/collection/_collection.json.jbuilder
@@ -5,6 +5,7 @@ json.related_url    single_collection['related_url_tesim']
 json.title    single_collection['title_tesim'].try(:first)
 json.resource_type    single_collection['resource_type_sim'].try(:first)
 json.date_created    single_collection['date_created_tesim']
+json.cname single_collection['account_cname_tesim'].first
 
 creator = single_collection['creator_tesim'].try(:first)
 if valid_json?(creator)

--- a/app/views/api/v1/work/_work.json.jbuilder
+++ b/app/views/api/v1/work/_work.json.jbuilder
@@ -23,6 +23,7 @@ if valid_json?(editor)
   json.editor JSON.parse(editor)
 end
 
+json.cname work['account_cname_tesim'].first
 json.abstract    work['abstract_tesim'].try(:first)
 json.date_published    work['date_published_tesim']
 json.institution    work['institution_tesim']


### PR DESCRIPTION
This PR adds the cname to work and collection endpoint to address the scenario in shared search where we have works from all tenants so we will know where to hyperlink the results to
