### PR TITLE
files and collection only available at single work endpoint

### DIFF
--- a/app/controllers/api/v1/work_controller.rb
+++ b/app/controllers/api/v1/work_controller.rb
@@ -16,6 +16,7 @@ class API::V1::WorkController < ActionController::Base
   end
 
   def show
+    @skip_run = 'true'
     time_stamp = Time.parse(@work['system_modified_dtsi'])
     fresh_when(last_modified: time_stamp, public: true)
   end

--- a/app/services/ubiquity/api_utils.rb
+++ b/app/services/ubiquity/api_utils.rb
@@ -9,8 +9,8 @@ module Ubiquity
       end
     end
 
-    def self.query_for_parent_collections(collection_ids)
-      if collection_ids.present?
+    def self.query_for_parent_collections(collection_ids, skip_run = nil)
+      if collection_ids.present? && skip_run == 'true'
         parent_collections = CatalogController.new.repository.search(q: "", fq: ["{!terms f=id}#{collection_ids.join(',')}"])
         parent_collections['response']['docs'].map do |doc|
           {uuid: doc['id'], title: doc['title_tesim'].try(:first)}
@@ -20,8 +20,8 @@ module Ubiquity
       end
     end
 
-    def self.query_for_files(file_ids)
-      if file_ids.present?
+    def self.query_for_files(file_ids, skip_run = nil)
+      if file_ids.present? && skip_run == 'true'
         child_files = CatalogController.new.repository.search(q: "", fq: ["{!terms f=id}#{file_ids.join(',')}"])
         child_files  #['response']['docs']
         file_count = child_files['response']['numFound']

--- a/app/views/api/v1/work/_work.json.jbuilder
+++ b/app/views/api/v1/work/_work.json.jbuilder
@@ -145,7 +145,7 @@ json.related_exhibition     work['related_exhibition_tesim']
 json.related_exhibition_date    work['related_exhibition_date_tesim']
 json.related_exhibition_venue     work['related_exhibition_venue_tesim']
 
-get_files =  Ubiquity::ApiUtils.query_for_files(work["file_set_ids_ssim"])
+get_files =  Ubiquity::ApiUtils.query_for_files(work["file_set_ids_ssim"],  @skip_run)
 
 if get_files.present?
   json.files get_files
@@ -153,7 +153,7 @@ else
   json.files  nil
 end
 
-get_collections =   Ubiquity::ApiUtils.query_for_parent_collections(work["member_of_collection_ids_ssim"])
+get_collections =   Ubiquity::ApiUtils.query_for_parent_collections(work["member_of_collection_ids_ssim"],  @skip_run)
 
 if get_collections.present?
   json.collections do


### PR DESCRIPTION
This PR removes files and collections from all the endpoint other than /work/id 