### PR TITLE
ensure the whole data obj is returned to retrieve the featured works

### DIFF
--- a/app/controllers/api/v1/highlights_controller.rb
+++ b/app/controllers/api/v1/highlights_controller.rb
@@ -64,6 +64,7 @@ class API::V1::HighlightsController < ActionController::Base
         #Re-order to the solr response to match the order that was work was featured in
         ordered_values = data['response']['docs'].group_by {|hash| hash['id']}.values_at(*ids).flatten
         data['response']['docs'] = ordered_values
+        data
       end
     end
   end


### PR DESCRIPTION
This Pr fixes a bug introduced with the previous PR below:
```
https://github.com/ubiquitypress/hyku/pull/609
```
The whole data obj is now correctly returned