### PR TITLE
passing the featured order to highlights end-point

### DIFF
--- a/app/views/api/v1/highlights/index.json.jbuilder
+++ b/app/views/api/v1/highlights/index.json.jbuilder
@@ -26,3 +26,8 @@ if recent.present?
 else
   json.recent_works nil
 end
+
+
+json.featured_order do
+  json.array! @featured
+end


### PR DESCRIPTION
This PR adds the a featured_order array to the highlights endpoint so the the order of the featured work can be arranged from the front-end