### PR TITLE
redirect work show page to react frontend

### DIFF
--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -26,12 +26,37 @@ module Ubiquity
 
     def set_role_dropdown_options(metadata_field, tenant_work_settings)
       role_key = "#{metadata_field}_roles"
-      options_array = metadata_field.present? ? tenant_work_settings.try(:present?) && tenant_work_settings[role_key] : nil 
+      options_array = metadata_field.present? ? tenant_work_settings.try(:present?) && tenant_work_settings[role_key] : nil
 
       if metadata_field == "creator"
         options_array || ['Faculty', 'Staff', 'Student', 'Other']
       elsif metadata_field == "contributor"
         options_array ||  ContributorGroupService.new.select_active_options.flatten.uniq!
+      end
+    end
+
+    def redirect_work_url(id = nil, original_url = nil)
+      subdomain = ubiquity_url_parser(original_url)
+      redirect_hash = redirection_settings(original_url)
+      if id.present? && redirect_hash.present? && redirect_hash[subdomain].present? && redirect_hash[subdomain]["url"].present?
+        "#{redirect_hash[subdomain]['url']}/work/#{id}"
+      end
+    end
+
+    def redirect_collection_url(id = nil, original_url = nil)
+      subdomain = ubiquity_url_parser(original_url)
+      redirect_hash = redirection_settings(original_url)
+      if id.present? && redirect_hash.present? && redirect_hash[subdomain].present? && redirect_hash[subdomain]["url"].present?
+        "#{redirect_hash[subdomain]['url']}/collection/#{id}"
+      end
+    end
+
+    private
+
+    def redirection_settings(original_url)
+      work_settings = get_tenant_work_settings
+      if  work_settings.present?
+        work_settings["redirect_show_link"]
       end
     end
 

--- a/app/views/hyrax/dashboard/collections/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_works.html.erb
@@ -10,21 +10,8 @@
 
       <%= render 'shared/ubiquity/thumbnail', document: document, presenter: presenter %>
 
-      <div class='media-body'>
-        <div class='media-heading'>
+      <%= render 'shared/ubiquity/dashboard/list_works', document: document %>
 
-          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
-            <span class="sr-only">
-              <%= t("hyrax.dashboard.my.sr.show_label") %>
-            </span>
-            <%= document.title_or_label %>
-          <% end %>
-
-          <br />
-          <%= render_collection_links(document) %>
-
-        </div>
-      </div>
     </div>
   </td>
 

--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -11,21 +11,8 @@
 
       <%= render 'shared/ubiquity/thumbnail', document: document, presenter:  Hyku::ManifestEnabledWorkShowPresenter.new(document, current_ability) %>
 
-      <div class='media-body'>
-        <div class='media-heading'>
-
-          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
-            <span class="sr-only">
-              <%= t("hyrax.dashboard.my.sr.show_label") %>
-            </span>
-            <%= document.title_or_label %>
-          <% end %>
-
-          <br />
-          <%= render_collection_links(document) %>
-
-        </div>
-      </div>
+      <%= render 'shared/ubiquity/dashboard/list_works', document: document %>
+    
     </div>
   </td>
 

--- a/app/views/hyrax/my/works/_list_works.html.erb
+++ b/app/views/hyrax/my/works/_list_works.html.erb
@@ -8,24 +8,10 @@
 
   <td>
     <div class='media'>
-
+      
       <%= render 'shared/ubiquity/thumbnail', document: document, presenter:  presenter %>
+      <%= render 'shared/ubiquity/dashboard/list_works', document: document %>
 
-      <div class='media-body'>
-        <div class='media-heading'>
-
-          <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
-            <span class="sr-only">
-              <%= t("hyrax.dashboard.my.sr.show_label") %>
-            </span>
-            <%= document.title_or_label %>
-          <% end %>
-
-          <br />
-          <%= render_collection_links(document) %>
-
-        </div>
-      </div>
     </div>
   </td>
 

--- a/app/views/shared/ubiquity/collections/_list_collections.html.erb
+++ b/app/views/shared/ubiquity/collections/_list_collections.html.erb
@@ -17,16 +17,29 @@
          <span class="fa fa-file-o grey-zip-icon pull-left collection-icon-small"></span>
         <% else %>
           <span  class="collection-icon-small pull-left"><%= render_thumbnail_tag document, :style => 'width:18px' %></span>
-      <% end %>
+        <% end %>
       <% else %>
           <!-- this was the default in hyrax -->
           <span class="<%# Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-small pull-left"></span>
       <% end %>
       <div class="media-body">
         <div class="media-heading">
-          <%= link_to hyrax.dashboard_collection_path(id) do %>
+
+          <% redirect_url = redirect_work_url(document.id, request.original_url) %>
+          <% if document.id && redirect_url.present? %>
+
+            <%= link_to redirect_url, target: :_blank do %>
               <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
               <%= document.title_or_label %>
+            <% end %>
+
+          <% else %>
+
+            <%= link_to hyrax.dashboard_collection_path(id) do %>
+              <span class="sr-only"><%= t("hyrax.dashboard.my.sr.show_label") %> </span>
+              <%= document.title_or_label %>
+            <% end %>
+
           <% end %>
           <a href="#" class="small" title="Click for more details">
             <i id="expand_<%= id %>" class="glyphicon glyphicon-chevron-right" aria-hidden="true"></i>

--- a/app/views/shared/ubiquity/collections/_show_document_list_row.html.erb
+++ b/app/views/shared/ubiquity/collections/_show_document_list_row.html.erb
@@ -24,12 +24,9 @@
   </td>
   <td>
     <div class="media">
-      <div class="media-body">
-        <h4 class="media-heading">
-          <%= link_to document.title_or_label, [main_app, document], id: "src_copy_link#{id}", class: "#{'document-title' if document.title_or_label == document.label}" %>
-        </h4>
-        <%= render_collection_links(document) %>
-      </div>
+
+      <%= render 'shared/ubiquity/dashboard/list_works', document: document %>
+
     </div>
   </td>
   <td>

--- a/app/views/shared/ubiquity/dashboard/_list_works.html.erb
+++ b/app/views/shared/ubiquity/dashboard/_list_works.html.erb
@@ -1,0 +1,32 @@
+<%# Copied from Hyrax, this file may be remove once integrated with Hyrax v2.1 %>
+<%# https://github.com/samvera/hyrax/blob/v2.1.0/app/views/hyrax/dashboard/works/_list_works.html.erb %>
+
+
+<!-- used in views/hyrax/dashboard/works/_list_works.html.erb  -->
+<!-- used in views/hyrax/dashboards/collections/_list_works.html.erb -->
+<!-- used in shared/ubiquity/collections/_show_document_list_row.html.erb -->
+
+<div class='media-body'>
+  <div class='media-heading'>
+
+    <% redirect_url = redirect_work_url(document.id, request.original_url) %>
+
+    <% if document.id && redirect_url.present? %>
+      <%= link_to redirect_url, id: "src_copy_link#{document.id}", target: :_blank, class: 'document-title' do %>
+        <span class="sr-only">  <%= t("hyrax.dashboard.my.sr.show_label") %></span>
+        <%= document.title_or_label %>
+      <% end %>
+
+    <% else %>
+
+      <%= link_to [main_app, document], id: "src_copy_link#{document.id}", class: 'document-title' do %>
+        <span class="sr-only"> <%= t("hyrax.dashboard.my.sr.show_label") %></span>
+        <%= document.title_or_label %>
+      <% end %>
+
+    <% end %>
+    <br />
+    <%= render_collection_links(document) %>
+
+  </div>
+</div>


### PR DESCRIPTION
Requires new settings in the environment variables eg if the tenant subdomain is live and demo, we will have:

     "redirect_show_link": {
                          "demo": {"url": "https://demo.pacific.us-frontend.ubiquityrepository.website"},
                           "live": {"url": "https://live.pacific.us-frontend.ubiquityrepository.website"}
                          }