### PR TITLE
move relationship in forms from a tab into the main form for pacific

### DIFF
--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -51,11 +51,8 @@ module Ubiquity
       end
     end
 
-    def check_should_not_use_fedora_association
-      settings_parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
-      tenant_work_settings_hash = settings_parser_class.per_account_tenant_settings_hash
-      subdomain = settings_parser_class.get_tenant_subdomain
-      tenant_work_settings_hash && tenant_work_settings_hash[subdomain] && tenant_work_settings_hash[subdomain]["turn_off_fedora_collection_work_association"]
+    def check_for_setting_value_in_tenant_settings(settings_key)
+      Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_settings_value_from_tenant_settings(settings_key)
     end
 
     private

--- a/app/services/ubiquity/parse_tenant_work_settings.rb
+++ b/app/services/ubiquity/parse_tenant_work_settings.rb
@@ -55,24 +55,30 @@ module Ubiquity
       end
      end
 
-    private
+     def get_settings_value_from_tenant_settings(settings_key)
+       tenant_work_settings_hash = per_account_tenant_settings_hash
+       subdomain = get_tenant_subdomain
+       per_account_tenant_settings_hash && per_account_tenant_settings_hash[subdomain] && per_account_tenant_settings_hash[subdomain][settings_key]
+     end
 
-    def tenant_work_settings_json
-      settings = ENV['TENANTS_WORK_SETTINGS']
-    end
+     private
 
-    def per_account_tenant_settings_json
-      settings = ENV['TENANTS_SETTINGS']
-    end
+     def tenant_work_settings_json
+       settings = ENV['TENANTS_WORK_SETTINGS']
+     end
 
-    def set_url(value)
-      parse_url = URI.parse(value)
-      if (parse_url.kind_of?(URI::HTTPS) || parse_url.kind_of?(URI::HTTP))
-        @url = parse_url
-      else
-        @url = nil
+     def per_account_tenant_settings_json
+       settings = ENV['TENANTS_SETTINGS']
+     end
+
+     def set_url(value)
+       parse_url = URI.parse(value)
+       if (parse_url.kind_of?(URI::HTTPS) || parse_url.kind_of?(URI::HTTP))
+         @url = parse_url
+       else
+         @url = nil
+       end
       end
-    end
 
   end
 end

--- a/app/views/hyrax/base/_form_rendering.html.erb
+++ b/app/views/hyrax/base/_form_rendering.html.erb
@@ -5,11 +5,13 @@
           Rendering
         </legend>
         <p>Select file(s) to be offered as as downloads for every image in Universal Viewer, for example a PDF of the whole <%= f.object.human_readable_type %>.</p>
-        <%= f.select :rendering_ids,
+        <% if f.object.model.try(:rendering_ids).present? %>
+          <%= f.select :rendering_ids,
                      f.object.select_files,
                      { include_blank: true },
                      { class: 'form-control', multiple: true } %>
+
+        <% end %>
       </fieldset>
     </div>
   </div>
-

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -1,75 +1,8 @@
-<%# file copied here by Ubiquity from Hyrax %>
+<!-- copied frm here and moved to the files below so we can remove relationship tab
+   in adapted_guts4form and add its content to shared/ubiquity/_form_metatdat  -->
 
-<%# we will yield to content_for for each tab, e.g. :files_tab %>
-<% tabs ||= %w[metadata files relationships notes] # default tab order %>
-<div class="row">
-  <div class="col-xs-12 col-sm-8">
-    <div class="panel panel-default tabs" role="main">
-      <!-- Nav tabs -->
-      <ul class="nav nav-tabs" role="tablist">
-        <% tabs.each_with_index do | tab, i | %>
-          <% if i == 0 %>
-            <li role="presentation" class="active">
-          <% else %>
-            <li role="presentation">
-          <% end %>
-            <% if tab == 'notes' %>
-              <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
-                <i class="fa fa-edit"></i> <%= t("hyrax.works.form.tab.#{tab}") %>
-                <% if curation_concern.id.present? %>
-                  <% notes_num = fetch_note_conversations(curation_concern.model_name.to_s, curation_concern.id).length %>
-                  <sup><%= notes_num if notes_num > 0 %></sup>
-                <% end %>
-              </a>
-            </li>
-            <% else %>
-              <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
-                <i class="fa icon-<%= tab %>"></i> <%= t("hyrax.works.form.tab.#{tab}") %>
-              </a>
-            </li>
-            <% end %>
-        <% end %>
-
-        <li role="presentation" id="tab-share" class="hidden">
-          <a href="#share" aria-controls="share" role="tab" data-toggle="tab">
-            <i class="fa icon-share"></i> <%= t("hyrax.works.form.tab.share") %>
-          </a>
-        </li>
-      </ul>
-
-      <!-- Tab panes -->
-      <div class="tab-content">
-        <% (tabs - ['share']).each_with_index do | tab, i | %>
-          <% if i == 0 %>
-            <div role="tabpanel" class="tab-pane active" id="<%= tab %>">
-          <% else %>
-            <div role="tabpanel" class="tab-pane" id="<%= tab %>">
-          <% end %>
-          <div class="form-tab-content">
-            <% # metadata_tab is sometimes provided %>
-            <%#= yield "#{tab}_tab".to_sym if content_for? "#{tab}_tab".to_sym %>
-            <%= render "form_#{tab}", f: f %>
-          </div>
-          </div>
-        <% end %>
-
-        <div role="tabpanel" class="tab-pane" id="share" data-param-key="<%= f.object.model_name.param_key %>">
-          <div class="form-tab-content">
-            <%= render "form_share", f: f %>
-          </div>
-        </div>
-        </div>
-      </div>
-    </div>
-    <% draft_doi = f.object.model.draft_doi %>
-    <div class='col-md-4 doi-save-draft-button-padding'>
-      <% if check_datacite_enable?(request.original_url) && draft_doi.blank?  %>
-        <% selected_option = 'Do not mint DOI' %>
-        <%= render 'ubiquity/external_services/datacite_suffix_generator', f: f %>
-      <%end%>
-    </div>
-    <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
-      <%= render 'form_progress', f: f %>
-    </div>
-  </div>
-</div>
+<% if check_for_setting_value_in_tenant_settings('hide_form_relationship_tab') == true %>
+  <%= render 'shared/ubiquity/works/adpated_guts4form', f: f %>
+<% else %>
+  <%= render 'shared/ubiquity/works/guts4form', f: f %>
+<% end %>

--- a/app/views/shared/ubiquity/works/_adpated_guts4form.html.erb
+++ b/app/views/shared/ubiquity/works/_adpated_guts4form.html.erb
@@ -1,0 +1,79 @@
+<%# file copied here by Ubiquity from Hyrax
+   and adpated version of 'shared/ubiquity/works/_guts4form.html.erb'
+ %>
+
+<%# we will yield to content_for for each tab, e.g. :files_tab %>
+<% tabs ||= %w[metadata files notes] # default tab order %>
+<div class="row">
+  <div class="col-xs-12 col-sm-8">
+    <div class="panel panel-default tabs" role="main">
+      <!-- Nav tabs -->
+      <ul class="nav nav-tabs" role="tablist">
+        <% tabs.each_with_index do | tab, i | %>
+          <% if i == 0 %>
+            <li role="presentation" class="active">
+          <% else %>
+            <li role="presentation">
+          <% end %>
+            <% if tab == 'notes' %>
+              <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+                <i class="fa fa-edit"></i> <%= t("hyrax.works.form.tab.#{tab}") %>
+                <% if curation_concern.id.present? %>
+                  <% notes_num = fetch_note_conversations(curation_concern.model_name.to_s, curation_concern.id).length %>
+                  <sup><%= notes_num if notes_num > 0 %></sup>
+                <% end %>
+              </a>
+            </li>
+            <% else %>
+              <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+                <i class="fa icon-<%= tab %>"></i> <%= t("hyrax.works.form.tab.#{tab}") %>
+              </a>
+            </li>
+            <% end %>
+        <% end %>
+
+        <li role="presentation" id="tab-share" class="hidden">
+          <a href="#share" aria-controls="share" role="tab" data-toggle="tab">
+            <i class="fa icon-share"></i> <%= t("hyrax.works.form.tab.share") %>
+          </a>
+        </li>
+      </ul>
+
+      <!-- Tab panes -->
+      <div class="tab-content">
+        <% (tabs - ['share']).each_with_index do | tab, i | %>
+          <% if i == 0 %>
+            <div role="tabpanel" class="tab-pane active" id="<%= tab %>">
+          <% else %>
+            <div role="tabpanel" class="tab-pane" id="<%= tab %>">
+          <% end %>
+          <div class="form-tab-content">
+            <% # metadata_tab is sometimes provided %>
+            <%#= yield "#{tab}_tab".to_sym if content_for? "#{tab}_tab".to_sym %>
+            <%= render "form_#{tab}", f: f if tab != "metadata" %>
+            <%= render "shared/ubiquity/works/form_#{tab}", f: f if tab == "metadata" %>
+
+          </div>
+          </div>
+        <% end %>
+
+        <div role="tabpanel" class="tab-pane" id="share" data-param-key="<%= f.object.model_name.param_key %>">
+          <div class="form-tab-content">
+            <%= render "form_share", f: f %>
+          </div>
+        </div>
+        </div>
+      </div>
+    </div>
+    <% draft_doi = f.object.model.draft_doi %>
+    <div class='col-md-4 doi-save-draft-button-padding'>
+      <% if check_datacite_enable?(request.original_url) && draft_doi.blank?  %>
+        <% selected_option = 'Do not mint DOI' %>
+        <%= render 'ubiquity/external_services/datacite_suffix_generator', f: f %>
+      <%end%>
+    </div>
+    <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+      <%= render 'form_progress', f: f %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/ubiquity/works/_form_member_of_collections.html.erb
+++ b/app/views/shared/ubiquity/works/_form_member_of_collections.html.erb
@@ -4,7 +4,7 @@
 <h2><%= t("hyrax.works.form.in_collections") %></h2>
 <div id="collection-widget">
 
-  <% if check_should_not_use_fedora_association.present? %>
+  <% if check_for_setting_value_in_tenant_settings("turn_off_fedora_collection_work_association") == 'true' %>
     <%= render 'shared/ubiquity/works/non_fedora_form_member_of_collections', f: f %>
   <% else %>
     <%= render 'shared/ubiquity/works/fedora_form_member_of_collections', f: f %>

--- a/app/views/shared/ubiquity/works/_form_metadata.html.erb
+++ b/app/views/shared/ubiquity/works/_form_metadata.html.erb
@@ -1,0 +1,31 @@
+<%# Called from hyku/app/views/hyrax/base/_form_relationships.html.erb %>
+<% if Flipflop.assign_admin_set? %>
+  <%# TODO: consider `Hyrax::AdminSetOptionsPresenter.select_options_for(controller: controller)` instead %>
+  <!-- include_blank: false, -->
+  <%= f.input :admin_set_id, as: :select,
+      collection: Hyrax::AdminSetOptionsPresenter.new(Hyrax::AdminSetService.new(controller)).select_options,
+       hint: 'Please you must select a an admin_set and ensure it has thesame name as the collection you are depositing into',
+      input_html: { class: 'form-control ubiquity-admin-set'} %>
+<% end %>
+
+<%# render 'form_in_works', f: f %>
+<%= render 'shared/ubiquity/works/form_member_of_collections', f: f %>
+
+<% if f.object.persisted? %>
+  <h2><%# t("hyrax.works.form.in_this_work") %></h2>
+  <%# render 'form_child_work_relationships', f: f %>
+<% end %>
+
+
+<%# Copied from hyrax/app/views/hyrax/base/_form_metadata.html.erb to remove the form instructions %>
+<div class="base-terms">
+  <% f.object.primary_terms.each do |term| %>
+    <%= render_edit_field_partial(term, f: f) %>
+  <% end %>
+</div>
+<div id="extended-terms">
+  <%= render 'form_media', f: f %>
+  <% f.object.secondary_terms.each do |term| %>
+    <%= render_edit_field_partial(term, f: f) %>
+  <% end %>
+</div>

--- a/app/views/shared/ubiquity/works/_guts4form.html.erb
+++ b/app/views/shared/ubiquity/works/_guts4form.html.erb
@@ -1,0 +1,78 @@
+<!-- file copied here by Ubiquity from Hyrax
+  from https://github.com/samvera/hyrax/blob/v2.0.2/app/views/hyrax/base/_guts4form.html.erb
+  used in views/hyrax/base/_guts4form.html.erb
+-->
+
+<%# we will yield to content_for for each tab, e.g. :files_tab %>
+<% tabs ||= %w[metadata files relationships notes] # default tab order %>
+<div class="row">
+  <div class="col-xs-12 col-sm-8">
+    <div class="panel panel-default tabs" role="main">
+      <!-- Nav tabs -->
+      <ul class="nav nav-tabs" role="tablist">
+        <% tabs.each_with_index do | tab, i | %>
+          <% if i == 0 %>
+            <li role="presentation" class="active">
+          <% else %>
+            <li role="presentation">
+          <% end %>
+            <% if tab == 'notes' %>
+              <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+                <i class="fa fa-edit"></i> <%= t("hyrax.works.form.tab.#{tab}") %>
+                <% if curation_concern.id.present? %>
+                  <% notes_num = fetch_note_conversations(curation_concern.model_name.to_s, curation_concern.id).length %>
+                  <sup><%= notes_num if notes_num > 0 %></sup>
+                <% end %>
+              </a>
+            </li>
+            <% else %>
+              <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+                <i class="fa icon-<%= tab %>"></i> <%= t("hyrax.works.form.tab.#{tab}") %>
+              </a>
+            </li>
+            <% end %>
+        <% end %>
+
+        <li role="presentation" id="tab-share" class="hidden">
+          <a href="#share" aria-controls="share" role="tab" data-toggle="tab">
+            <i class="fa icon-share"></i> <%= t("hyrax.works.form.tab.share") %>
+          </a>
+        </li>
+      </ul>
+
+      <!-- Tab panes -->
+      <div class="tab-content">
+        <% (tabs - ['share']).each_with_index do | tab, i | %>
+          <% if i == 0 %>
+            <div role="tabpanel" class="tab-pane active" id="<%= tab %>">
+          <% else %>
+            <div role="tabpanel" class="tab-pane" id="<%= tab %>">
+          <% end %>
+          <div class="form-tab-content">
+            <% # metadata_tab is sometimes provided %>
+            <%#= yield "#{tab}_tab".to_sym if content_for? "#{tab}_tab".to_sym %>
+            <%= render "form_#{tab}", f: f %>
+          </div>
+          </div>
+        <% end %>
+
+        <div role="tabpanel" class="tab-pane" id="share" data-param-key="<%= f.object.model_name.param_key %>">
+          <div class="form-tab-content">
+            <%= render "form_share", f: f %>
+          </div>
+        </div>
+        </div>
+      </div>
+    </div>
+    <% draft_doi = f.object.model.draft_doi %>
+    <div class='col-md-4 doi-save-draft-button-padding'>
+      <% if check_datacite_enable?(request.original_url) && draft_doi.blank?  %>
+        <% selected_option = 'Do not mint DOI' %>
+        <%= render 'ubiquity/external_services/datacite_suffix_generator', f: f %>
+      <%end%>
+    </div>
+    <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+      <%= render 'form_progress', f: f %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/ubiquity/works/_non_fedora_form_member_of_collections.html.erb
+++ b/app/views/shared/ubiquity/works/_non_fedora_form_member_of_collections.html.erb
@@ -5,7 +5,9 @@
            as: :select,
            collection: f.object.collections_for_select,
            selected: f.object.non_fedora_association_collection_id(params[:add_works_to_collection]),
-           input_html: { class: 'form-control', multiple: true } %>
+           hint: 'Please you must select a collection. Make sure the selected collection matches the name of the admin set above',
+           label: 'Collection',
+           input_html: { class: 'form-control', multiple: true, prompt: 'pick' } %>
 
 <% elsif current_user.present?  & !current_ability.admin? %>
 
@@ -13,6 +15,8 @@
            as: :select,
            collection: f.object.public_collections_for_select,
            selected: f.object.non_fedora_association_collection_id(params[:add_works_to_collection]),
-           input_html: { class: 'form-control', multiple: true } %>
+           hint: 'Please you must select a collection. Make sure the selected collection matches the name of the admin set above',
+           label: 'Collection',
+           input_html: { class: 'form-control', multiple: true, prompt: 'pick' } %>
 
 <% end %>


### PR DESCRIPTION
Requires the addition to TENANT_SETTINGS environment variable the key and value below:
   
        "hide_form_relationship_tab": true