### PR TITLE
Repo 634/further settings refactor

### DIFF
--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -28,18 +28,16 @@ module Ubiquity
     end
 
     def redirect_work_url(id = nil, original_url = nil)
-      subdomain = ubiquity_url_parser(original_url)
       redirect_hash = redirection_settings(original_url)
-      if id.present? && redirect_hash.present? && redirect_hash[subdomain].present? && redirect_hash[subdomain]["url"].present?
-        "#{redirect_hash[subdomain]['url']}/work/#{id}"
+      if id.present? && redirect_hash.present? && redirect_hash['live'].present?
+        "https://#{redirect_hash['live']}/work/#{id}"
       end
     end
 
     def redirect_collection_url(id = nil, original_url = nil)
-      subdomain = ubiquity_url_parser(original_url)
       redirect_hash = redirection_settings(original_url)
-      if id.present? && redirect_hash.present? && redirect_hash[subdomain].present? && redirect_hash[subdomain]["url"].present?
-        "#{redirect_hash[subdomain]['url']}/collection/#{id}"
+      if id.present? && redirect_hash.present? && redirect_hash['live'].present?
+        "https://#{redirect_hash['live']}/collection/#{id}"
       end
     end
 
@@ -58,11 +56,11 @@ module Ubiquity
     private
 
     def redirection_settings(original_url)
+      subdomain = ubiquity_url_parser(original_url)
       settings = get_tenant_settings
       if  settings.present?
-        settings["redirect_show_link"]
+        settings[subdomain]
       end
     end
-
   end
 end

--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -41,7 +41,7 @@ module Ubiquity
       end
     end
 
-    # THESE WILE END OF THE WORK. I AM KEEPING THEM HERE SO THAT I KNOW WHAT METHODS TO REPLACE
+    # THESE WILL BE GONE BY END OF THE WORK. I AM KEEPING THEM HERE SO THAT I KNOW WHAT METHODS TO REPLACE
 
     # def check_for_per_account_value_in_tenant_settings(settings_key)
     #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_per_account_settings_value_from_tenant_settings(settings_key)

--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -41,17 +41,29 @@ module Ubiquity
       end
     end
 
-    def check_for_per_account_value_in_tenant_settings(settings_key)
-      Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_per_account_settings_value_from_tenant_settings(settings_key)
+    # THESE WILE END OF THE WORK. I AM KEEPING THEM HERE SO THAT I KNOW WHAT METHODS TO REPLACE
+
+    # def check_for_per_account_value_in_tenant_settings(settings_key)
+    #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_per_account_settings_value_from_tenant_settings(settings_key)
+    # end
+    #
+    # def check_for_setting_value_in_tenant_settings(settings_key)
+    #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_settings_value_from_tenant_settings(settings_key)
+    # end
+    #
+    # def check_for_nested_value_in_tenant_settings(settings_key1,settings_key2)
+    #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_nested_settings_value_from_tenant_settings(settings_key1, settings_key2)
+    # end
+
+    def check_for_setting(settings_key)
+      parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
+      parser_class.get_per_account_settings_value_from_tenant_settings(settings_key) || parser_class.get_settings_value_from_tenant_settings(settings_key)
     end
 
-    def check_for_setting_value_in_tenant_settings(settings_key)
-      Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_settings_value_from_tenant_settings(settings_key)
-    end
+    def check_for_nested_setting(settings_key1,settings_key2)
+      parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
+      parser_class.get_per_account_nested_settings_value_from_tenant_settings(settings_key1,settings_key2) || get_nested_settings_value_from_tenant_settings(settings_key1, settings_key2)
 
-    def check_for_nested_value_in_tenant_settings(settings_key1,settings_key2)
-      Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_nested_settings_value_from_tenant_settings(settings_key1, settings_key2)
-    end
 
     private
 

--- a/app/models/concerns/ubiquity/email_format.rb
+++ b/app/models/concerns/ubiquity/email_format.rb
@@ -6,6 +6,14 @@ module Ubiquity
       validate :must_have_valid_email_format
     end
 
+    def current_account_name
+      Account.find_by(tenant: Apartment::Tenant.current).name
+    end
+
+    def get_subdomain
+      current_account_name.split('.').first
+    end
+
     def get_tenant_settings
       json_data = ENV['TENANTS_SETTINGS']
         if json_data.present? && json_data.class == String
@@ -14,7 +22,9 @@ module Ubiquity
     end
 
     def must_have_valid_email_format
-      format = get_tenant_settings['email_format']
+      subdomain = get_subdomain
+      format = get_tenant_settings[subdomain]['email_format']
+      puts "FORMAT IS #{format}"
       if format.present?
         email_format = '@' + email.split('@')[-1]
         errors.add(:email, "Email must contain #{format[0]}") unless format.include? email_format

--- a/app/models/concerns/ubiquity/email_format.rb
+++ b/app/models/concerns/ubiquity/email_format.rb
@@ -24,7 +24,6 @@ module Ubiquity
     def must_have_valid_email_format
       subdomain = get_subdomain
       format = get_tenant_settings[subdomain]['email_format']
-      puts "FORMAT IS #{format}"
       if format.present?
         email_format = '@' + email.split('@')[-1]
         errors.add(:email, "Email must contain #{format[0]}") unless format.include? email_format

--- a/app/services/ubiquity/parse_tenant_work_settings.rb
+++ b/app/services/ubiquity/parse_tenant_work_settings.rb
@@ -23,8 +23,9 @@ module Ubiquity
     end
 
     def redirection_settings_hash
+      subdomain = get_tenant_subdomain
       if tenant_settings_hash.present?
-        tenant_settings_hash["redirect_show_link"]
+        tenant_settings_hash[subdomain]["live"]
       end
     end
 
@@ -37,7 +38,7 @@ module Ubiquity
 
     def redirect_url
       if redirect_subdomain_url_hash.present?
-        redirect_subdomain_url_hash['url']
+        "https://#{redirect_subdomain_url_hash}"
       end
     end
 

--- a/app/services/ubiquity/parse_tenant_work_settings.rb
+++ b/app/services/ubiquity/parse_tenant_work_settings.rb
@@ -65,6 +65,11 @@ module Ubiquity
        work_settings_hash && work_settings_hash[settings_key1] && work_settings_hash[settings_key1][settings_key2]
      end
 
+     def get_per_account_nested_settings_value_from_tenant_settings(settings_key1,settings_key2)
+       account_settings_hash = tenant_settings_hash
+       subdomain = get_tenant_subdomain
+       account_settings_hash && account_settings_hash[subdomain] && account_settings_hash[subdomain][settings_key1] && account_settings_hash[subdomain][settings_key1][settings_key2]
+     end
 
      private
 


### PR DESCRIPTION
In the interests of keeping PR's small I am putting in a PR now before I replace all the methods. 
I couldn't get the helpers into the email_validator class, feel free to refactor.

This PR:

1. Moves Email validation into per account settings
2. Removes the redirect show link setting
3. Adds methods to look for a default setting if non is found in the per account setting

The next PR will refactor all parts of the code to use either the check_for_setting or check_for_nested_setting for pulling data from the hash 