### PR TITLE
Repo 634/further settings refactor

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticate_user_from_jwt_token!
-    shared_login = helpers.check_for_per_account_value_in_tenant_settings("shared_login")
+    shared_login = helpers.check_for_setting("shared_login")
     token = get_auth_token
 
     if shared_login.present? && token.present?
@@ -71,7 +71,7 @@ class ApplicationController < ActionController::Base
 
     # Overwriting the sign_out redirect path method
     def after_sign_out_path_for(resource_or_scope)
-      url_path = helpers.check_for_per_account_value_in_tenant_settings('live')
+      url_path = helpers.check_for_setting('live')
       if url_path.present?
         ("https://" + url_path).strip
       else

--- a/app/controllers/concerns/ubiquity/collections_controller_override.rb
+++ b/app/controllers/concerns/ubiquity/collections_controller_override.rb
@@ -60,7 +60,7 @@ module Ubiquity
       settings_parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
       settings_hash = settings_parser_class.tenant_settings_hash
       subdomain = settings_parser_class.get_tenant_subdomain
-      settings_hash && settings_hash[subdomain] && settings_hash[subdomain]["turn_off_fedora_collection_work_association"]
+      settings_hash && settings_hash[subdomain] && settings_hash[subdomain]["turn_off_fedora_collection_work_association"] || settings_hash["turn_off_fedora_collection_work_association"]
     end
 
     private

--- a/app/controllers/concerns/ubiquity/file_sets_controller_override.rb
+++ b/app/controllers/concerns/ubiquity/file_sets_controller_override.rb
@@ -5,7 +5,8 @@ module Ubiquity
     private
 
     def redirect?
-      true if Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_settings_value_from_tenant_settings('redirect_on')
+      parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
+      true if parser_class.get_per_account_settings_value_from_tenant_settings('redirect_on') || parser_class.get_settings_value_from_tenant_settings('redirect_on')
     end
 
     def after_update_response

--- a/app/controllers/concerns/ubiquity/works_controller_behaviour_override.rb
+++ b/app/controllers/concerns/ubiquity/works_controller_behaviour_override.rb
@@ -18,7 +18,7 @@ module Ubiquity
       settings_parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
       settings_hash = settings_parser_class.tenant_settings_hash
       subdomain = settings_parser_class.get_tenant_subdomain
-      settings_hash && settings_hash[subdomain] && settings_hash[subdomain]["turn_off_fedora_collection_work_association"]
+      settings_hash && settings_hash[subdomain] && settings_hash[subdomain]["turn_off_fedora_collection_work_association"] || settings_hash["turn_off_fedora_collection_work_association"]
     end
 
     def set_collection_id_and_collection_names
@@ -38,7 +38,8 @@ module Ubiquity
     end
 
     def redirect?
-      true if Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_settings_value_from_tenant_settings('redirect_on') == 'true'
+      parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
+      true if parser_class.get_per_account_settings_value_from_tenant_settings('redirect_on') == 'true' || parser_class.get_settings_value_from_tenant_settings('redirect_on') == 'true'
     end
 
 

--- a/app/forms/concerns/ubiquity/hyrax_work_form_override.rb
+++ b/app/forms/concerns/ubiquity/hyrax_work_form_override.rb
@@ -8,14 +8,14 @@ module Ubiquity
     end
 
     def not_needed_fields
-          parser_class = Ubiquity::ParseTenantWorkSettings.new(account_cname)
-          unwanted_fields_hash = parser_class.check_for_setting('work_unwanted_fields')
-          selected_work = self.class.to_s.gsub("Hyrax::", '').gsub('Form', '').underscore
-          if unwanted_fields_hash.present? && unwanted_fields_hash.keys.include?(selected_work)
-            array_of_fields = unwanted_fields_hash[selected_work].split(',')
-            array_of_fields.map{|ele| ele.to_sym}
-          end
-        end
+      parser_class = Ubiquity::ParseTenantWorkSettings.new(account_cname)
+      unwanted_fields_hash = parser_class.get_per_account_settings_value_from_tenant_settings('work_unwanted_fields') || parser_class.get_settings_value_from_tenant_settings('work_unwanted_fields')
+      selected_work = self.class.to_s.gsub("Hyrax::", '').gsub('Form', '').underscore
+      if unwanted_fields_hash.present? && unwanted_fields_hash.keys.include?(selected_work)
+        array_of_fields = unwanted_fields_hash[selected_work].split(',')
+        array_of_fields.map{|ele| ele.to_sym}
+      end
+    end
 
     def primary_terms
        terms - [:collection_id, :collection_names]

--- a/app/forms/concerns/ubiquity/hyrax_work_form_override.rb
+++ b/app/forms/concerns/ubiquity/hyrax_work_form_override.rb
@@ -9,7 +9,7 @@ module Ubiquity
 
     def not_needed_fields
           parser_class = Ubiquity::ParseTenantWorkSettings.new(account_cname)
-          unwanted_fields_hash = parser_class.get_settings_value_from_tenant_settings('work_unwanted_fields')
+          unwanted_fields_hash = parser_class.check_for_setting('work_unwanted_fields')
           selected_work = self.class.to_s.gsub("Hyrax::", '').gsub('Form', '').underscore
           if unwanted_fields_hash.present? && unwanted_fields_hash.keys.include?(selected_work)
             array_of_fields = unwanted_fields_hash[selected_work].split(',')

--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -41,20 +41,6 @@ module Ubiquity
       end
     end
 
-
-    # THESE WILL BE GONE BY END OF THE WORK. I AM KEEPING THEM HERE SO THAT I KNOW WHAT METHODS TO REPLACE
-    # def check_for_setting(settings_key)
-    #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_per_account_settings_value_from_tenant_settings(settings_key)
-    # end
-    #
-    # def check_for_setting(settings_key)
-    #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_settings_value_from_tenant_settings(settings_key)
-    # end
-    #
-    # def check_for_nested_setting(settings_key1,settings_key2)
-    #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_nested_settings_value_from_tenant_settings(settings_key1, settings_key2)
-    # end
-
     def check_for_setting(settings_key)
       parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
       parser_class.get_per_account_settings_value_from_tenant_settings(settings_key) || parser_class.get_settings_value_from_tenant_settings(settings_key)

--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -41,8 +41,8 @@ module Ubiquity
       end
     end
 
-    # THESE WILL BE GONE BY END OF THE WORK. I AM KEEPING THEM HERE SO THAT I KNOW WHAT METHODS TO REPLACE
 
+    # THESE WILL BE GONE BY END OF THE WORK. I AM KEEPING THEM HERE SO THAT I KNOW WHAT METHODS TO REPLACE
     # def check_for_per_account_value_in_tenant_settings(settings_key)
     #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_per_account_settings_value_from_tenant_settings(settings_key)
     # end
@@ -63,6 +63,7 @@ module Ubiquity
     def check_for_nested_setting(settings_key1,settings_key2)
       parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
       parser_class.get_per_account_nested_settings_value_from_tenant_settings(settings_key1,settings_key2) || get_nested_settings_value_from_tenant_settings(settings_key1, settings_key2)
+    end
 
 
     private

--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -43,7 +43,7 @@ module Ubiquity
 
 
     # THESE WILL BE GONE BY END OF THE WORK. I AM KEEPING THEM HERE SO THAT I KNOW WHAT METHODS TO REPLACE
-    # def check_for_per_account_value_in_tenant_settings(settings_key)
+    # def check_for_setting(settings_key)
     #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_per_account_settings_value_from_tenant_settings(settings_key)
     # end
     #

--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -47,7 +47,7 @@ module Ubiquity
     #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_per_account_settings_value_from_tenant_settings(settings_key)
     # end
     #
-    # def check_for_setting_value_in_tenant_settings(settings_key)
+    # def check_for_setting(settings_key)
     #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_settings_value_from_tenant_settings(settings_key)
     # end
     #

--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -51,7 +51,7 @@ module Ubiquity
     #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_settings_value_from_tenant_settings(settings_key)
     # end
     #
-    # def check_for_nested_value_in_tenant_settings(settings_key1,settings_key2)
+    # def check_for_nested_setting(settings_key1,settings_key2)
     #   Ubiquity::ParseTenantWorkSettings.new(request.original_url).get_nested_settings_value_from_tenant_settings(settings_key1, settings_key2)
     # end
 

--- a/app/helpers/ubiquity/settings_helper.rb
+++ b/app/helpers/ubiquity/settings_helper.rb
@@ -62,7 +62,7 @@ module Ubiquity
 
     def check_for_nested_setting(settings_key1,settings_key2)
       parser_class = Ubiquity::ParseTenantWorkSettings.new(request.original_url)
-      parser_class.get_per_account_nested_settings_value_from_tenant_settings(settings_key1,settings_key2) || get_nested_settings_value_from_tenant_settings(settings_key1, settings_key2)
+      parser_class.get_per_account_nested_settings_value_from_tenant_settings(settings_key1,settings_key2) || parser_class.get_nested_settings_value_from_tenant_settings(settings_key1, settings_key2)
     end
 
 

--- a/app/models/concerns/ubiquity/work_type_validator.rb
+++ b/app/models/concerns/ubiquity/work_type_validator.rb
@@ -14,7 +14,7 @@ module Ubiquity
 
     def get_work_list
       parser_class = Ubiquity::ParseTenantWorkSettings.new(self.account_cname)
-      work_list = parser_class.get_per_account_settings_value_from_tenant_settings("work_type_list")
+      work_list = parser_class.get_per_account_settings_value_from_tenant_settings("work_type_list") || parser_class.get_settings_value_from_tenant_settings("work_type_list")
       work_types_array = work_list.presence && work_list.split(',')
       work_types_array.present? ? work_types_array.map {|i| i.classify.constantize} : Hyrax.config.curation_concerns
     end

--- a/app/presenters/concerns/ubiquity/select_type_list_presenter_override.rb
+++ b/app/presenters/concerns/ubiquity/select_type_list_presenter_override.rb
@@ -15,7 +15,7 @@ module Ubiquity
 
       def return_custom_work_list
         parser_class = Ubiquity::ParseTenantWorkSettings.new(current_account_name)
-        work_list = parser_class.get_per_account_settings_value_from_tenant_settings("work_type_list")
+        work_list = parser_class.get_per_account_settings_value_from_tenant_settings("work_type_list") || parser_class.get_settings_value_from_tenant_settings("work_type_list")
         work_list_array = work_list.presence && work_list.split(',')
         if work_list_array.present?
           @authorized_models = work_list_array

--- a/app/services/ubiquity/shared_methods.rb
+++ b/app/services/ubiquity/shared_methods.rb
@@ -3,7 +3,7 @@ module Ubiquity
 
     def self.tenant_work_list(cname_or_original_url)
       parser_class = Ubiquity::ParseTenantWorkSettings.new(cname_or_original_url)
-      settings_object = parser_class.get_per_account_settings_value_from_tenant_settings("work_type_list")
+      settings_object = parser_class.get_per_account_settings_value_from_tenant_settings("work_type_list") || parser_class.get_settings_value_from_tenant_settings("work_type_list")
       list_of_work_names_in_string_array  = settings_object && settings_object.split(',').compact
       list_of_works_classes = list_of_work_names_in_string_array  && list_of_work_names_in_string_array .map {|model| model.constantize}
       list_of_works_classes || Hyrax.config.curation_concerns

--- a/app/views/_logo.html.erb
+++ b/app/views/_logo.html.erb
@@ -2,7 +2,7 @@
   to conditionally change Hyku label for BL
 -->
 
-<% url_path = check_for_per_account_value_in_tenant_settings('live') %>
+<% url_path = check_for_setting('live') %>
 <% path_to_use = url_path.present? ? ("https://" + url_path).strip : hyrax.root_path  %>
 
 <% if ENV['SHOW_LOG_OUT'] == 'true' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,7 @@
 
         <div class="form-inputs">
             <%= f.input :display_name, required: true, wrapper: :inline %>
-            <%= f.input :email, required: true, autofocus: true, wrapper: :inline, hint: check_for_per_account_value_in_tenant_settings('email_hint_text') || ' '%>
+            <%= f.input :email, required: true, autofocus: true, wrapper: :inline, hint: check_for_setting('email_hint_text') || ' '%>
             <%= f.input :password, required: true, wrapper: :inline %>
             <%= f.input :password_confirmation, required: true, wrapper: :inline %>
         </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= check_for_setting_value_in_tenant_settings('sign_up_link') == 'true' ? (link_to t(".sign_up"), new_registration_path(resource_name)) : ' ' %><br />
+  <%= check_for_setting('sign_up_link') == 'true' ? (link_to t(".sign_up"), new_registration_path(resource_name)) : ' ' %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>

--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -1,7 +1,7 @@
 <!-- copied frm here and moved to the files below so we can remove relationship tab
    in adapted_guts4form and add its content to shared/ubiquity/_form_metatdat  -->
 
-<% if check_for_per_account_value_in_tenant_settings('hide_form_relationship_tab') == true %>
+<% if check_for_setting('hide_form_relationship_tab') == true %>
   <%= render 'shared/ubiquity/works/adpated_guts4form', f: f %>
 <% else %>
   <%= render 'shared/ubiquity/works/guts4form', f: f %>

--- a/app/views/records/edit_fields/_add_info.html.erb
+++ b/app/views/records/edit_fields/_add_info.html.erb
@@ -1,4 +1,4 @@
 <%= f.input :add_info, as: :text,
             input_html: { class: 'ubiquity-add_info' },
             label: 'Additional Information',
-            hint: check_for_nested_value_in_tenant_settings('help_texts','additional_information') %>
+            hint: check_for_nested_setting('help_texts','additional_information') %>

--- a/app/views/records/edit_fields/_isbn.html.erb
+++ b/app/views/records/edit_fields/_isbn.html.erb
@@ -1,3 +1,3 @@
 <%= f.input :isbn,
             input_html: { class: 'ubiquity-isbn' },
-            hint: check_for_nested_value_in_tenant_settings('help_texts','isbn') %>
+            hint: check_for_nested_setting('help_texts','isbn') %>

--- a/app/views/records/edit_fields/_issn.html.erb
+++ b/app/views/records/edit_fields/_issn.html.erb
@@ -1,3 +1,3 @@
 <%= f.input :issn,
             input_html: { class: 'ubiquity-issn' },
-            hint: check_for_nested_value_in_tenant_settings('help_texts','issn')%>
+            hint: check_for_nested_setting('help_texts','issn')%>

--- a/app/views/records/edit_fields/_keyword.html.erb
+++ b/app/views/records/edit_fields/_keyword.html.erb
@@ -1,4 +1,4 @@
 <%= f.input :keyword, as: :multi_value,
             input_html: { class: 'ubiquity-keyword form-control', multiple: true },
             required: f.object.required?(key),
-            hint: check_for_nested_value_in_tenant_settings('help_texts','keyword') %>
+            hint: check_for_nested_setting('help_texts','keyword') %>

--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -1,7 +1,7 @@
 <% account_local_name =  ubiquity_url_parser(request.original_url) %>
 <% license_service = Hyrax::LicenseService.new %>
 
-<% licence_list = check_for_setting_value_in_tenant_settings('licence_list') %>
+<% licence_list = check_for_setting('licence_list') %>
 
 <% licence_dropdown = licence_list || license_service.select_active_options %>
 

--- a/app/views/records/edit_fields/_org_unit.html.erb
+++ b/app/views/records/edit_fields/_org_unit.html.erb
@@ -1,4 +1,4 @@
-<% label_name = check_for_nested_value_in_tenant_settings('metadata_labels','org_unit') || "organisational unit".capitalize  %>
+<% label_name = check_for_nested_setting('metadata_labels','org_unit') || "organisational unit".capitalize  %>
 
 <% my_model_name = f.object.model.class.to_s.underscore %>
 
@@ -6,7 +6,7 @@
   <%= label_name %>
   <span class="label label-info required-tag">required</span>
 </label>
-<p class="help-block"><%= check_for_nested_value_in_tenant_settings('help_texts','org_unit') %> </p>
+<p class="help-block"><%= check_for_nested_setting('help_texts','org_unit') %> </p>
 
 <%= text_field_tag "#{my_model_name}[org_unit][]", f.object.model.org_unit.first, id: "#{my_model_name}_org_unit",
   class: "form-control text required form-control ubiquity-org-unit" , required: "required" %>

--- a/app/views/records/edit_fields/_pagination.html.erb
+++ b/app/views/records/edit_fields/_pagination.html.erb
@@ -1,3 +1,3 @@
 <%= f.input :pagination,
             input_html: { class: 'ubiquity-pagination' },
-            hint: check_for_nested_value_in_tenant_settings('help_texts','pagination')%>
+            hint: check_for_nested_setting('help_texts','pagination')%>

--- a/app/views/records/edit_fields/_publisher.html.erb
+++ b/app/views/records/edit_fields/_publisher.html.erb
@@ -2,5 +2,5 @@
 
 <%= f.input :publisher, as: :multi_value,
             input_html: { class: 'ubiquity-publisher form-control' },
-            hint: check_for_nested_value_in_tenant_settings('help_texts','publisher') %>
+            hint: check_for_nested_setting('help_texts','publisher') %>
 <br>

--- a/app/views/records/edit_fields/_refereed.html.erb
+++ b/app/views/records/edit_fields/_refereed.html.erb
@@ -2,4 +2,4 @@
             collection: RefereedService.select_options,
             include_blank: true,
             input_html: { class: 'form-control' },
-            hint: check_for_nested_value_in_tenant_settings('help_texts','refereed') %>
+            hint: check_for_nested_setting('help_texts','refereed') %>

--- a/app/views/records/edit_fields/_subject.html.erb
+++ b/app/views/records/edit_fields/_subject.html.erb
@@ -4,4 +4,4 @@
             collection: subject_service.select_active_options,
             include_blank: true,
             input_html: { class: 'form-control ubiquity-subject'},
-            hint: check_for_nested_value_in_tenant_settings('help_texts','subject') %>
+            hint: check_for_nested_setting('help_texts','subject') %>

--- a/app/views/records/edit_fields/_version_number.html.erb
+++ b/app/views/records/edit_fields/_version_number.html.erb
@@ -1,7 +1,7 @@
 <% my_model_name = f.object.model.class.to_s.underscore %>
 
-<label class="control-label" for="<%= my_model_name %>_version_number"><%= check_for_nested_value_in_tenant_settings('metadata_labels','version_number')%></label>
-<p class="help-block"><%= check_for_nested_value_in_tenant_settings('help_texts','version_number') %></p>
+<label class="control-label" for="<%= my_model_name %>_version_number"><%= check_for_nested_setting('metadata_labels','version_number')%></label>
+<p class="help-block"><%= check_for_nested_setting('help_texts','version_number') %></p>
 <%= text_field_tag "#{my_model_name}[version_number][]", f.object.model.version_number.first, id: "#{my_model_name}_version_number",
   class: "form-control ubiquity-version-number" %>
 <br>

--- a/app/views/records/edit_fields/_volume.html.erb
+++ b/app/views/records/edit_fields/_volume.html.erb
@@ -1,7 +1,7 @@
 <% my_model_name = f.object.model.class.to_s.underscore %>
 
 <label class="control-label" for="<%= my_model_name %>_volume">Volume</label>
-<p class='help-block'> <%= check_for_nested_value_in_tenant_settings('help_texts','volume')%></p>
+<p class='help-block'> <%= check_for_nested_setting('help_texts','volume')%></p>
 <%= text_field_tag "#{my_model_name}[volume][]", f.object.model.volume.first, id: "#{my_model_name}_volume",
   class: "form-control ubiquity-volume" %>
 <br>

--- a/app/views/shared/ubiquity/contributor/_contributor_form_fields.html.erb
+++ b/app/views/shared/ubiquity/contributor/_contributor_form_fields.html.erb
@@ -6,7 +6,7 @@
 <% array_of_hash = get_model( f.object.contributor, template, 'contributor', 'contributor_position') %>
 <% array_of_hash = array_of_hash ||  [{}] %>
 
-<% required_toggle = check_for_nested_value_in_tenant_settings('html_required','contributor')%>
+<% required_toggle = check_for_nested_setting('html_required','contributor')%>
 <% contributor_list = list_of_json_properties('contributor') %>
 <% span_content = required_toggle.present? ? 'required' : ' ' %>
 <% span_content_css = required_toggle.present? ? 'label label-info required-tag' : ' ' %>

--- a/app/views/shared/ubiquity/json_fields_partials/_family_name.html.erb
+++ b/app/views/shared/ubiquity/json_fields_partials/_family_name.html.erb
@@ -1,4 +1,4 @@
-<% label_name = check_for_nested_value_in_tenant_settings('metadata_labels', 'family_name') || "#{metadata_field.capitalize} family name"  %>
+<% label_name = check_for_nested_setting('metadata_labels', 'family_name') || "#{metadata_field.capitalize} family name"  %>
 
 
 <label class="control-label multi_value optional" for="#{template}_#{metadata_field}_family_name">

--- a/app/views/shared/ubiquity/json_fields_partials/_given_name.html.erb
+++ b/app/views/shared/ubiquity/json_fields_partials/_given_name.html.erb
@@ -1,4 +1,4 @@
-<% label_name = check_for_nested_value_in_tenant_settings('metadata_labels', 'given_name') || "#{metadata_field.capitalize} given name"  %>
+<% label_name = check_for_nested_setting('metadata_labels', 'given_name') || "#{metadata_field.capitalize} given name"  %>
 
 
 <label class="control-label multi_value optional" for="#{template}_#{metadata_field}_given_name">

--- a/app/views/shared/ubiquity/json_fields_partials/_institutional_relationship.html.erb
+++ b/app/views/shared/ubiquity/json_fields_partials/_institutional_relationship.html.erb
@@ -1,5 +1,5 @@
 <% dropdown_list = check_for_setting('institutional_relationship').split(',') %>
-<% label_name =  check_for_nested_value_in_tenant_settings('metadata_labels', 'institutional_relationship') || "#{metadata_field.capitalize} institutional relationship"  %>
+<% label_name =  check_for_nested_setting('metadata_labels', 'institutional_relationship') || "#{metadata_field.capitalize} institutional relationship"  %>
 <% property_hash = check_for_setting("required_json_property") %>
 <% template = f.object.model.class.to_s.underscore %>
 

--- a/app/views/shared/ubiquity/json_fields_partials/_institutional_relationship.html.erb
+++ b/app/views/shared/ubiquity/json_fields_partials/_institutional_relationship.html.erb
@@ -1,12 +1,12 @@
-<% dropdown_list = check_for_setting_value_in_tenant_settings('institutional_relationship').split(',') %>
+<% dropdown_list = check_for_setting('institutional_relationship').split(',') %>
 <% label_name =  check_for_nested_value_in_tenant_settings('metadata_labels', 'institutional_relationship') || "#{metadata_field.capitalize} institutional relationship"  %>
-<% property_hash = check_for_setting_value_in_tenant_settings("required_json_property") %>
+<% property_hash = check_for_setting("required_json_property") %>
 <% template = f.object.model.class.to_s.underscore %>
 
 <p><label class="control-label multi_value optional" for="#{template}_#{metadata_field}_institutional_relationship">
 <%= label_name %>  </label></p> <span class='error'> </span>
 
-<% if check_for_setting_value_in_tenant_settings("institutional_relationship_picklist") == "true"  %>
+<% if check_for_setting("institutional_relationship_picklist") == "true"  %>
 
   <%= render 'shared/ubiquity/json_fields_partials/institutional_dropdown', property_hash: property_hash, template: template, metadata_field: metadata_field, dropdown_list: dropdown_list, hash: hash %>
 

--- a/app/views/shared/ubiquity/works/_form_member_of_collections.html.erb
+++ b/app/views/shared/ubiquity/works/_form_member_of_collections.html.erb
@@ -4,7 +4,7 @@
 <h2><%= t("hyrax.works.form.in_collections") %></h2>
 <div id="collection-widget">
 
-  <% if check_for_per_account_value_in_tenant_settings("turn_off_fedora_collection_work_association") == 'true' %>
+  <% if check_for_setting("turn_off_fedora_collection_work_association") == 'true' %>
     <%= render 'shared/ubiquity/works/non_fedora_form_member_of_collections', f: f %>
   <% else %>
     <%= render 'shared/ubiquity/works/fedora_form_member_of_collections', f: f %>


### PR DESCRIPTION
Most of this PR is just method name changes and adding or statements. This should make every setting available in both the main hash and the per account hash, allowing default settings 