### PR TITLE
Added funder group fields and form templates

### DIFF
--- a/app/forms/ubiquity/all_forms_shared_behaviour.rb
+++ b/app/forms/ubiquity/all_forms_shared_behaviour.rb
@@ -15,6 +15,9 @@ module Ubiquity
                     :creator_family_name, :creator_orcid, :creator_isni, :creator_ror, :creator_grid,
                     :creator_wikidata, :creator_position, :creator_institutional_relationship
 
+      attr_accessor :funder_group, :funder_name, :funder_doi, :funder_award, :funder_position,
+                    :funder_orcid, :funder_isni, :funder_ror
+
       attr_accessor :alternate_identifier_group, :related_identifier_group,
                     :date_published_group, :date_accepted_group, :date_submitted_group,
                     :event_date, :related_exhibition_date
@@ -59,6 +62,10 @@ module Ubiquity
           permitted_params << {creator_group: [:creator_organization_name, :creator_given_name,
             :creator_family_name, :creator_name_type, :creator_orcid, :creator_isni,  :creator_ror, :creator_grid,
             :creator_wikidata, :creator_position, :creator_institutional_relationship => []
+          ]}
+
+          permitted_params << {funder_group: [:funder_name, :funder_doi, :funder_position,
+            :funder_orcid, :funder_isni, :funder_ror, :funder_award => []
           ]}
 
           permitted_params << { alternate_identifier_group: %i[alternate_identifier alternate_identifier_type] }

--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -7,6 +7,7 @@ module Ubiquity
 
       before_save :save_contributor
       before_save :save_creator
+      before_save :save_funder
       before_save :save_alternate_identifier
       before_save :save_related_identifier
       before_save :save_date_published, :save_date_accepted, :save_date_submitted,
@@ -16,7 +17,7 @@ module Ubiquity
 
       #These are used in the forms to populate fields that will be stored in json fields
       #The json fields in this case are creator, contributor, alternate_identifier and related_identifier
-      attr_accessor :creator_group, :contributor_group, :alternate_identifier_group, :related_identifier_group,
+      attr_accessor :creator_group, :contributor_group, :funder_group, :alternate_identifier_group, :related_identifier_group,
                     :date_published_group, :date_accepted_group, :date_submitted_group,
                     :event_date_group, :related_exhibition_date_group
     end
@@ -68,6 +69,18 @@ module Ubiquity
         self.creator_search = []
         #save an empty array since the submitted data contains only default keys & values
         self.creator = []
+      end
+    end
+
+    def save_funder
+      self.funder_group ||= JSON.parse(self.funder.first) if self.funder.present?
+      clean_submitted_data ||= remove_hash_keys_with_empty_and_nil_values(self.funder_group)
+      data = compare_hash_keys?(clean_submitted_data)
+      if (self.funder_group.present? && clean_submitted_data.present? && data == false )
+        funder_json = clean_submitted_data.to_json
+        self.funder = [funder_json]
+      elsif data == true || data == nil
+       self.funder = []
       end
     end
 

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -17,7 +17,7 @@
 <%= presenter.attribute_to_html(:institution, render_as: :alphabetical_sort) %>
 <%= presenter.attribute_to_html(:org_unit, render_as: :alphabetical_sort, label: "Organisational unit") %>
 <%= presenter.attribute_to_html(:project_name) %>
-<%= presenter.attribute_to_html(:funder, render_as: :alphabetical_sort) %>
+<%= render "shared/ubiquity/funder/show", presenter: presenter %>
 <%= presenter.attribute_to_html(:fndr_project_ref, render_as: :alphabetical_sort, label: "Funder project reference") %>
 <%= presenter.attribute_to_html(:event_title, render_as: :alphabetical_sort) %>
 <%= presenter.attribute_to_html(:event_location, render_as: :alphabetical_sort) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -17,7 +17,7 @@
 <%= presenter.attribute_to_html(:institution, render_as: :alphabetical_sort) %>
 <%= presenter.attribute_to_html(:org_unit, render_as: :alphabetical_sort, label: "Organisational unit") %>
 <%= presenter.attribute_to_html(:project_name) %>
-<%= presenter.attribute_to_html(:funder, render_as: :alphabetical_sort) %>
+<%#= presenter.attribute_to_html(:funder, render_as: :alphabetical_sort) %>
 <%= render "shared/ubiquity/funder/show", presenter: presenter %>
 <%= presenter.attribute_to_html(:fndr_project_ref, render_as: :alphabetical_sort, label: "Funder project reference") %>
 <%= presenter.attribute_to_html(:event_title, render_as: :alphabetical_sort) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -17,6 +17,7 @@
 <%= presenter.attribute_to_html(:institution, render_as: :alphabetical_sort) %>
 <%= presenter.attribute_to_html(:org_unit, render_as: :alphabetical_sort, label: "Organisational unit") %>
 <%= presenter.attribute_to_html(:project_name) %>
+<%= presenter.attribute_to_html(:funder, render_as: :alphabetical_sort) %>
 <%= render "shared/ubiquity/funder/show", presenter: presenter %>
 <%= presenter.attribute_to_html(:fndr_project_ref, render_as: :alphabetical_sort, label: "Funder project reference") %>
 <%= presenter.attribute_to_html(:event_title, render_as: :alphabetical_sort) %>

--- a/app/views/records/edit_fields/_funder.html.erb
+++ b/app/views/records/edit_fields/_funder.html.erb
@@ -1,20 +1,14 @@
-<% template = f.object.model.class.to_s.underscore %>
-<label class="control-label multi_value optional" for="#{template}_funder">Funder</label>
-<p class="help-block">Use full name e.g. Arts and Humanities Research Council</p>
-<%= select_tag "#{template}[funder][]",
-      options_from_collection_for_select(FunderService.new.select_active_options.flatten.uniq!, :to_s, :to_s, f.object.model.funder.to_a),
-        class: "ubiquity-autocomplete", include_blank: true, multiple: true, data: {placeholder: "start typing a funder for autocompletion"}
-%>
-
-<br/><br/>
-
-<script>
-  $(document).on("turbolinks:load", function(event){
-    $("body").on("click",".additional-fields", function(event){
-      $(".ubiquity-autocomplete").chosen({
-        allow_single_deselect: true,
-        width: '100%'
-      });
-    });
-  });
-</script>
+<% if  f.object.model.new_record? %>
+  <%= render "shared/ubiquity/funder/new_form", f: f %>
+<% else %>
+<% array_of_hash = get_model(f.object.model.funder, f.object.model.class.to_s, 'funder', 'funder_position') %>
+<!--
+Clicking edit button returns an error it is something other than an array of hash
+it will throw either ActionView::Template::Error (undefined method `each_with_index' for nil:NilClass)
+  or
+ActionView::Template::Error (undefined method `dig' for "null":String):
+The line below fixes that
+-->
+<% array_of_hash = array_of_hash || [{}] %>
+  <%= render "shared/ubiquity/funder/edit_array_hash_form", array_of_hash: array_of_hash, f: f %>
+<% end %>

--- a/app/views/shared/ubiquity/funder/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/funder/_edit_array_hash_form.html.erb
@@ -11,7 +11,10 @@
                         class: "#{template}_funder_group form-control multi-text-field multi_value ubiquity_funder_name",
                         placeholder: 'Please enter the Funder Name',
                         name: "#{template}[funder_group][][funder_name]",
-                        data: {field_name:'ubiquity_funder_name'}
+                        data: { field_name:'ubiquity_funder_name',
+                          'autocomplete-url' => '/authorities/search/local/funder',
+                          autocomplete: 'funder'
+                        }
     %>
     <br/>
     <label class="control-label multi_value optional" for="#{template}funder_doi">

--- a/app/views/shared/ubiquity/funder/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/funder/_edit_array_hash_form.html.erb
@@ -1,0 +1,50 @@
+<% template = f.object.model.class.to_s.underscore %>
+
+
+<% array_of_hash.each_with_index do |hash, index| %>
+  <div class="ubiquity-meta-funder" >
+
+    <label class="control-label multi_value optional" for="#{template}_funder_name">
+      Funder Name</label>
+
+    <%= text_field_tag "#{template}[funder_group][][funder_name]", hash.dig("funder_name"),
+                        class: "#{template}_funder_group form-control multi-text-field multi_value ubiquity_funder_name",
+                        placeholder: 'Please enter the Funder Name',
+                        name: "#{template}[funder_group][][funder_name]",
+                        data: {field_name:'ubiquity_funder_name'}
+    %>
+    <br/>
+    <label class="control-label multi_value optional" for="#{template}funder_doi">
+      Funder DOI</label>
+
+    <%= text_field_tag "#{template}[funder_group][][funder_doi]",  hash.dig("funder_doi"),
+                       class: "#{template}_funder_group form-control multi-text-field multi_value ubiquityfunder_doi",
+                       placeholder: "Please enter the DOI",
+                       name: "#{template}[funder_group][][funder_doi]",
+                       data: {field_name:'ubiquityfunder_doi'}
+    %>
+    <br/>
+    <label class="control-label multi_value optional" for="#{template}funder_ror">
+      Funder ROR</label>
+
+    <%= text_field_tag "#{template}[funder_group][][funder_ror]",  hash.dig("funder_ror"),
+                       class: "#{template}_funder_group form-control multi-text-field multi_value ubiquityfunder_ror",
+                       placeholder: "Please enter the ror",
+                       name: "#{template}[funder_group][][funder_ror]",
+                       data: {field_name:'ubiquityfunder_ror'}
+    %>
+    <br/>
+
+    <%= hidden_field_tag "#{template}[funder_group][][funder_position]", index, class: 'ubiquity-funder-score'  %>
+
+    <a href="#" style="color:red;"  class="remove_Funder form-group " data-removeUbiquityfunder=".ubiquity-meta-funder">
+      <span class="glyphicon glyphicon-remove"></span>
+      <span class="controls-remove-text">Remove</span>
+    </a>
+    |
+    <a href="#" class=" add_funder" data-addUbiquityFunder=".ubiquity-meta-funder">Add another </a>
+
+    <br><br><br>
+
+  </div>
+<% end %>

--- a/app/views/shared/ubiquity/funder/_new_form.html.erb
+++ b/app/views/shared/ubiquity/funder/_new_form.html.erb
@@ -1,0 +1,51 @@
+<% template = f.object.model.class.to_s.underscore %>
+
+
+<div class="ubiquity-meta-funder" >
+  <label class="control-label multi_value optional" for="#{template}_funder_name">
+    Funder Name</label>
+
+  <%= text_field_tag "#{template}[funder_group][][funder_name]", nil,
+                     class: "#{template}_funder_group form-control multi-text-field multi_value ubiquity_funder_name",
+                     placeholder: 'Please enter the funder\'s name',
+                     name: "#{template}[funder_group][][funder_name]",
+                     data: { field_name:'ubiquity_funder_name',
+                             'autocomplete-url' => '/authorities/search/local/funder',
+                             autocomplete: 'funder'
+                           }
+  %>
+
+  <br>
+  <label class="control-label multi_value optional" for="#{template}_funder_doi">
+    Funder DOI</label>
+
+  <%= text_field_tag "#{template}[creator_group][][funder_doi]", nil,
+                     class: "#{template}_funder_group form-control multi-text-field multi_value ubiquity_funder_doi",
+                     placeholder: "Please enter Funder DOI",
+                     name: "#{template}[funder_group][][funder_doi]",
+                     data: {field_name:'ubiquity_funder_doi'}
+  %>
+
+  <br>
+  <label class="control-label multi_value optional" for="#{template}_funder_ror">
+    Funder ROR </label>
+
+  <%= text_field_tag "#{template}[funder_group][][funder_ror]", nil,
+                     class: "#{template}_funder_group form-control multi-text-field multi_value ubiquity_funder_ror",
+                     placeholder: "Please enter the ROR",
+                     name: "#{template}[funder_group][][funder_ror]",
+                     data: {field_name:'ubiquity_funder_ror'}
+
+  %>
+ <br>
+  <%= hidden_field_tag "#{template}[funder_group][][funder_position]", 1, class: 'ubiquity-funder-score'  %>
+
+  <a href="#" style="color:red;"  class=" remove_funder form-group " data-removeUbiquityfunder=".ubiquity-meta-funder">
+    <span class="glyphicon glyphicon-remove"></span>
+    <span class="controls-remove-text">Remove</span>
+  </a>
+  |
+  <a href="#" class=" add_funder" data-addUbiquityfunder=".ubiquity-meta-funder">Add another </a>
+
+  <br/><br/>
+</div>

--- a/app/views/shared/ubiquity/funder/_show.html.erb
+++ b/app/views/shared/ubiquity/funder/_show.html.erb
@@ -1,0 +1,8 @@
+<!-- rendered from views/hyrax/base///_attribute_rows.html.erb -->
+
+<% array_of_hash = get_model(presenter.funder, presenter.model, 'funder', 'funder_position') %>
+
+ <% if (array_of_hash.class == Array && array_of_hash.first.class == Hash )  %>
+
+   <%= render "shared/ubiquity/funder/show_array_hash", array_of_hash: array_of_hash  %>
+<% end %>

--- a/app/views/shared/ubiquity/funder/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/funder/_show_array_hash.html.erb
@@ -1,0 +1,22 @@
+<tr>
+  <th>Funder</th>
+  <td>
+    <ul class="tabular">
+      <% array_of_hash.each do |hash| %>
+        <li class="attribute funder">
+          <span itemprop="funder" style="float:left">
+            <% order_ary = ['funder_name', 'funder_doi']%>
+            <%= display_data_with_comma_separated(hash, order_ary)%>
+          </span>
+        <li>
+        <li>
+          <% hash['funder_award'].each do |award| %>
+            <span itemprop="funder" style="float:left">
+              <%= award %>
+            </span>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </td>
+</tr>

--- a/app/views/shared/ubiquity/funder/_show_array_hash.html.erb
+++ b/app/views/shared/ubiquity/funder/_show_array_hash.html.erb
@@ -3,17 +3,28 @@
   <td>
     <ul class="tabular">
       <% array_of_hash.each do |hash| %>
-        <li class="attribute funder">
-          <span itemprop="funder" style="float:left">
-            <% order_ary = ['funder_name', 'funder_doi']%>
-            <%= display_data_with_comma_separated(hash, order_ary)%>
-          </span>
+        <li class="attribute funder name">
+          <% if hash['funder_name'].present? %>
+            <%= "name: #{hash['funder_name']}" %>&nbsp;
+          <% end %>
+        </li>
+        <li class="attribute funder doi">
+          <% if hash['funder_doi'].present? %>
+            <%= "DOI: #{hash['funder_doi']}" %>&nbsp;
+          <% end %>
+        </li>
+        <li class="attribute funder ror">
+          <% if hash['funder_ror'].present? %>
+            <%= "ROR ID: #{hash['funder_ror']}" %>&nbsp;
+          <% end %>
+        </li>
         <li>
-        <li>
-          <% hash['funder_award'].each do |award| %>
-            <span itemprop="funder" style="float:left">
-              <%= award %>
-            </span>
+          <% if hash['funder_award'] %>
+            <% hash['funder_award'].each do |award| %>
+              <span itemprop="funder" style="float:left">
+                <%= award %>
+              </span>
+            <% end %>
           <% end %>
         </li>
       <% end %>


### PR DESCRIPTION
### REPO-718

I- n the deposit form, use Java script to select a Funder (this is no longer a controlled picklist of approx 40 funders, but is instead an auto-suggesting field which is based on the Crossref Funder Registry of over 21,000 funders).

- When a funder has been selected, then the ISNI and ROR IDs are populated from either a local copy of the ROR registry or via the ROR API (this is a registry of over 97,000 research organisations).

- Leave a free text field for Funder name non included in the registry

- Use Funder DOI from CrossRef as Funder ID

- Allow Multiple Funders

- Use both ISNI + ROR for each Funder in separate fields

