### PR TITLE
Override QA's method for constructing Crossref label

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -189,3 +189,5 @@ Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
 Qa::Authorities::Local.register_subauthority('subjects', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
 Qa::Authorities::Local.register_subauthority('genres', 'Qa::Authorities::Local::TableBasedAuthority')
+
+Qa::Authorities::Crossref::GenericAuthority.label = lambda { |item| [item['name'], item['location']].compact.join(', ') }


### PR DESCRIPTION
Drop alt-names from constructed label

I tested this locally in a different Hyrax app.

Before change:
```
2.7.1 :001 > Qa::Authorities::Crossref::GenericAuthority.new('funders').search("ash")
 => [{:id=>"100011055", :uri=>"http://dx.doi.org/10.13039/100011055", :label=>"American Society of Hypertension, (ASH), United States", :value=>"American Society of Hypertension"}, {:id=>"100001422", :uri=>"http://dx.doi.org/10.13039/100001422", :label=>"American Society of Hematology, (ASH, The American Society of Hematology), United States", :value=>"American Society of Hematology"}, {:id=>"100002607", :uri=>"http://dx.doi.org/10.13039/100002607", :label=>"American Speech-Language-Hearing Foundation, (American Speech Language Hearing Association, ASHA, ASHA Foundation, ASHFoundation), United States", :value=>"American Speech-Language-Hearing Foundation"}...]
```

After change:
```
2.7.1 :002 > Qa::Authorities::Crossref::GenericAuthority.new('funders').search("ash")
 => [{:id=>"100011055", :uri=>"http://dx.doi.org/10.13039/100011055", :label=>"American Society of Hypertension, United States", :value=>"American Society of Hypertension"}, {:id=>"100001422", :uri=>"http://dx.doi.org/10.13039/100001422", :label=>"American Society of Hematology, United States", :value=>"American Society of Hematology"}, {:id=>"100002607", :uri=>"http://dx.doi.org/10.13039/100002607", :label=>"American Speech-Language-Hearing Foundation, United States", :value=>"American Speech-Language-Hearing Foundation"}, {:id=>"100013453", :uri=>"http://dx.doi.org/10.13039/100013453", :label=>"American Speech-Language-Hearing Association, United States", :value=>"American Speech-Language-Hearing Association"}...]
```
