### PR TITLE
Only mark personal fields mandatory when type dropdown is set to Personal

### DIFF
--- a/app/assets/javascripts/ubiquity/orcid_isni_validation.js
+++ b/app/assets/javascripts/ubiquity/orcid_isni_validation.js
@@ -72,7 +72,7 @@ function checkForPresenceOfOrcidValue(field, index){
     if ((drop_down_val == 'Organisational') && (check_for_org_value == '') && (check_for_isni_value != '')) {
       addOrganisationNameMandatory(field, index);
     }
-    else if (check_for_name) {
+    else if ((drop_down_val == 'Personal') && check_for_name) {
       var check_for_value = ($('.ubiquity_'+field+'_family_name_x'+ index).val() != '') || ($('.ubiquity_'+field+'_given_name_x'+index).val() != '');
       if (check_for_value == false){
         addFieldsNamesMandatoryForPersonalFields(field, index);


### PR DESCRIPTION
The problem was that after setting a contributor to Organisational and filling in the name and isni the check on line 72 failed and the check on 75 passed and since family name and given name are present but empty it went on to execute 78.  This change skips the check on 75 as it should when the type is Organisational.
