### PR TITLE
Add underscore so CSS class names match those used in new form

### DIFF
--- a/app/views/shared/ubiquity/funder/_edit_array_hash_form.html.erb
+++ b/app/views/shared/ubiquity/funder/_edit_array_hash_form.html.erb
@@ -21,30 +21,30 @@
       Funder DOI</label>
 
     <%= text_field_tag "#{template}[funder_group][][funder_doi]",  hash.dig("funder_doi"),
-                       class: "#{template}_funder_group form-control multi-text-field multi_value ubiquityfunder_doi",
+                       class: "#{template}_funder_group form-control multi-text-field multi_value ubiquity_funder_doi",
                        placeholder: "Please enter the DOI",
                        name: "#{template}[funder_group][][funder_doi]",
-                       data: {field_name:'ubiquityfunder_doi'}
+                       data: {field_name:'ubiquity_funder_doi'}
     %>
     <br/>
     <label class="control-label multi_value optional" for="#{template}funder_isni">
       Funder ISNI</label>
 
     <%= text_field_tag "#{template}[funder_group][][funder_isni]",  hash.dig("funder_isni"),
-                       class: "#{template}_funder_group form-control multi-text-field multi_value ubiquityfunder_isni",
+                       class: "#{template}_funder_group form-control multi-text-field multi_value ubiquity_funder_isni",
                        placeholder: "Please enter the ISNI",
                        name: "#{template}[funder_group][][funder_isni]",
-                       data: {field_name:'ubiquityfunder_isni'}
+                       data: {field_name:'ubiquity_funder_isni'}
     %>
     <br/>
     <label class="control-label multi_value optional" for="#{template}funder_ror">
       Funder ROR</label>
 
     <%= text_field_tag "#{template}[funder_group][][funder_ror]",  hash.dig("funder_ror"),
-                       class: "#{template}_funder_group form-control multi-text-field multi_value ubiquityfunder_ror",
+                       class: "#{template}_funder_group form-control multi-text-field multi_value ubiquity_funder_ror",
                        placeholder: "Please enter the ROR",
                        name: "#{template}[funder_group][][funder_ror]",
-                       data: {field_name:'ubiquityfunder_ror'}
+                       data: {field_name:'ubiquity_funder_ror'}
     %>
     <br/>
     <div class='form-group'>


### PR DESCRIPTION
Because the CSS classes were named differently the funder autocomplete callback wasn't able to set the ROR and ISNI as was working on the new form. See https://github.com/ubiquitypress/hyku/blob/test/app/assets/javascripts/ubiquity/funder_autocomplete_callback.js#L22-L23

@BertZZ I'm not able to test this change since it is server-side, but I'm pretty confident in it.