### PR TITLE
Create ubiquity_cleanup_uploads_job.rb

### DIFF
--- a/app/jobs/ubiquity_cleanup_uploads_job.rb
+++ b/app/jobs/ubiquity_cleanup_uploads_job.rb
@@ -1,0 +1,19 @@
+class UbiquityCleanupUploadsJob < ActiveJob::Base
+  non_tenant_job
+
+  def perform
+    Account.all.each do |account|
+      AccountElevator.switch!(account.cname)
+      Rails.logger.debug("Running uploads cleanup on #{account.cname}")
+      Hyrax::UploadedFile.where.not(file_set_uri: nil).each do |upload|
+        begin do
+          disk_checksum = Digest::SHA1.file upload.file.path
+          fedora_checksum = FileSet.find(upload.file_set_uri.split('/').last).original_file.checksum.value
+          File.rm(upload.file.path) if (disk_checksum == fedora_checksum) && (upload.updated_at < Time.now.utc - 7.days)
+        rescue Exception => e
+          Rails.logger.error("Error verifying checksum or removing file (#{upload.file.path}): #{e.full_message}")
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/ubiquity_cleanup_uploads_job.rb
+++ b/app/jobs/ubiquity_cleanup_uploads_job.rb
@@ -6,6 +6,7 @@ class UbiquityCleanupUploadsJob < ActiveJob::Base
       AccountElevator.switch!(account.cname)
       Rails.logger.debug("Running uploads cleanup on #{account.cname}")
       Hyrax::UploadedFile.where.not(file_set_uri: nil).each do |upload|
+        next unless upload.file.file.exists?
         begin do
           disk_checksum = Digest::SHA1.file upload.file.path
           fedora_checksum = FileSet.find(upload.file_set_uri.split('/').last).original_file.checksum.value


### PR DESCRIPTION
Delete files from the uploads directory (but retain the UploadedFile DB record) if their checksum on disk matches what is stored in the file's metadata in Fedora AND it is older than 7 days.
This hasn't been tested and needs to be before running on production.

Fixes  REPO-815