### PR TITLE
Fix issues with Uploads cleanup job

### DIFF
--- a/app/jobs/ubiquity_cleanup_uploads_job.rb
+++ b/app/jobs/ubiquity_cleanup_uploads_job.rb
@@ -7,12 +7,13 @@ class UbiquityCleanupUploadsJob < ActiveJob::Base
       Rails.logger.debug("Running uploads cleanup on #{account.cname}")
       Hyrax::UploadedFile.where.not(file_set_uri: nil).each do |upload|
         next unless upload.file.file.exists?
-        begin do
+        begin
           disk_checksum = Digest::SHA1.file upload.file.path
           fedora_checksum = FileSet.find(upload.file_set_uri.split('/').last).original_file.checksum.value
-          File.rm(upload.file.path) if (disk_checksum == fedora_checksum) && (upload.updated_at < Time.now.utc - 7.days)
+          File.delete(upload.file.path) if (disk_checksum == fedora_checksum) && (upload.updated_at < Time.now.utc - 7.days)
         rescue Exception => e
-          Rails.logger.error("Error verifying checksum or removing file (#{upload.file.path}): #{e.full_message}")
+          # TODO: handle specific errors like Ldp::Gone where it should be safe to delete the uploaded file
+          Rails.logger.error("Error verifying checksum or removing file (#{upload.file.path}): #{e.to_s}")
         end
       end
     end


### PR DESCRIPTION
Bad syntax with `begin`
`File.delete` is a real method while `File.rm` isn't
Use less helpful `exception.to_s` because Ldp::Gone doesn't work well with `full_message`
Added comment about future work

With these changes, I was able to manually run the job on repo-test.ubiquity.press and it removed ~7G of files (out of 11G):
```
I, [2020-10-26T20:34:22.176124 #4118]  INFO -- : [ActiveJob] [UbiquityCleanupUploadsJob] [64fe6655-8f06-4e92-b413-aef2f18a78be] Performed UbiquityCleanupUploadsJob (Job ID: 64fe6655-8f06-4e92-b413-aef2f18a78be) from Sidekiq(default) in 691399.29ms
```
