### PR TITLE
Gurads against blank data_hash value

### DIFF
--- a/app/models/concerns/ubiquity/all_models_virtual_fields.rb
+++ b/app/models/concerns/ubiquity/all_models_virtual_fields.rb
@@ -292,6 +292,7 @@ module Ubiquity
     end
 
     def clean_incomplete_data(data_hash)
+      return if data_hash.empty?
       field_name = get_field_name(data_hash)
       data_hash.each do |hash|
         if (hash["#{field_name}_family_name"].blank? && hash["#{field_name}_organization_name"].blank?)


### PR DESCRIPTION
When trying to import contributors without a contributor the code was dealing with the contributor block by making the value a string of ```"contributor"=>["\"\""]```

This PR guards against a blank string slipping through into this method