### PR TITLE
Force https links for all urls generated by devise emails.

### DIFF
--- a/app/mailers/hyku_mailer.rb
+++ b/app/mailers/hyku_mailer.rb
@@ -1,7 +1,7 @@
 # Provides a default host for the current tenant
 class HykuMailer < ActionMailer::Base
   def default_url_options
-    { host: host_for_tenant }
+    { host: host_for_tenant, protocol: 'https' }
   end
 
   private


### PR DESCRIPTION
Fixes REPO-829.